### PR TITLE
Reexport 'core' functionality for use in derives

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -169,6 +169,12 @@ pub use leb128::*;
 #[cfg(feature = "std")]
 pub use lesser::*;
 
+#[doc(hidden)]
+pub mod export {
+    pub use ::core::result;
+    pub use ::core::mem;
+}
+
 #[cfg(test)]
 mod tests {
     #[allow(overflowing_literals)]


### PR DESCRIPTION
After `scroll_derive` is updated to use these, the 'std' dependency for `derive` can be deleted in `Cargo.toml`.