### PR TITLE
Run the examples in the README as doctests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,3 +6,7 @@ rust:
 matrix:
   allow_failures:
     - rust: nightly
+
+script:
+  - cargo build --verbose --features=derive
+  - RUST_BACKTRACE=1 cargo test --all --verbose --features=derive

--- a/README.md
+++ b/README.md
@@ -79,6 +79,43 @@ fn main() {
 }
 ```
 
+### Deriving `Pread` and `Pwrite`
+
+Scroll implements a custom derive that can provide `Pread` and `Pwrite` implementations for your types.
+
+``` rust
+#[macro_use]
+extern crate scroll;
+
+use scroll::{Pread, Pwrite, BE};
+
+#[derive(Pread, Pwrite)]
+struct Data {
+    one: u32,
+    two: u16,
+    three: u8,
+}
+
+fn parse() -> Result<(), scroll::Error> {
+    let bytes: [u8; 7] = [0xde, 0xad, 0xbe, 0xef, 0xfa, 0xce, 0xff];
+    // Read a single `Data` at offset zero in big-endian byte order.
+    let data: Data = bytes.pread_with(0, BE)?;
+    assert_eq!(data.one, 0xdeadbeef);
+    assert_eq!(data.two, 0xface);
+    assert_eq!(data.three, 0xff);
+
+    // Write it back to a buffer
+    let mut out: [u8; 7] = [0; 7];
+    out.pwrite_with(data, 0, BE)?;
+    assert_eq!(bytes, out);
+    Ok(())
+}
+
+fn main() {
+  parse().unwrap();
+}
+```
+
 # `std::io` API
 
 Scroll can also read/write simple types from a `std::io::Read` or `std::io::Write` implementor. The  built-in numeric types are taken care of for you.  If you want to read a custom type, you need to implement the `FromCtx` (_how_ to parse) and `SizeWith` (_how_ big the parsed thing will be) traits.  You must compile with default features. For example:

--- a/tests/readme.rs
+++ b/tests/readme.rs
@@ -1,0 +1,28 @@
+use std::env;
+use std::env::consts::EXE_EXTENSION;
+use std::path::Path;
+use std::process::Command;
+
+#[test]
+fn readme_test() {
+    let rustdoc = Path::new("rustdoc").with_extension(EXE_EXTENSION);
+    let readme = Path::new(file!()).parent().unwrap().parent().unwrap().join("README.md");
+    let exe = env::current_exe().unwrap();
+    let depdir = exe.parent().unwrap();
+    let outdir = depdir.parent().unwrap();
+    let extern_arg = format!("scroll={}", outdir.join("libscroll.rlib").to_string_lossy());
+    let mut cmd = Command::new(rustdoc);
+    cmd.args(&["--verbose", "--test", "-L"])
+        .arg(&outdir)
+        .arg("-L")
+        .arg(&depdir)
+        .arg("--extern")
+        .arg(&extern_arg)
+        .arg(&readme);
+    println!("Running `{:?}`", cmd);
+    let result = cmd.spawn()
+        .expect("Failed to spawn process")
+        .wait()
+        .expect("Failed to run process");
+    assert!(result.success(), "Failed to run rustdoc tests on README.md!");
+}


### PR DESCRIPTION
I don't know if you actually want this, but I wanted to write an example of using scroll_derive, and I realized that the examples in the README weren't being tested. I wired them up with my current best skeptic approximation that doesn't pull in any dependencies, but it requires some fiddling with the examples because they don't get an automatic `extern crate scroll` for some reason when run this way. They wind up looking slightly uglier, but it does ensure that they work!

The second commit then adds an example with derive, and tweaks your Travis CI config to build with `--features=derive` so it works. One quirky thing here is that if someone does `cargo test` without that feature, that test will fail to compile. I don't know if that concerns you or not. If it does, I could make that work by splitting it out to a separate markdown file.