### PR TITLE
Serialize/Deserialize a std::ffi::CStr

### DIFF
--- a/src/ctx.rs
+++ b/src/ctx.rs
@@ -530,9 +530,7 @@ impl<'a> TryFromCtx<'a> for &'a CStr {
             })
         };
 
-        let data = src.get(..null_byte+1).unwrap();
-
-        let cstr = unsafe { CStr::from_bytes_with_nul_unchecked(data) };
+        let cstr = unsafe { CStr::from_bytes_with_nul_unchecked(&src[..null_byte+1]) };
         Ok((cstr, null_byte+1))
     }
 }


### PR DESCRIPTION
This PR adds implementations of `TryIntoCtx` and `TryFromCtx` for `&CStr` and `CString` when compiling with the `std` feature enabled. 

We could probably speed the `TryFromCtx` up a little bit by using something like `memchr` for finding the string's null terminator seeing as that's the most expensive part, but that adds an extra dependency and I wasn't sure whether it was necessary.