### PR TITLE
Make i128/u128 support conditional on Rust 1.26.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,9 @@ description = "A suite of powerful, extensible, generic, endian-aware Read/Write
 [dependencies]
 scroll_derive = { version = "0.9", optional = true }
 
+[build-dependencies]
+rustc_version = "0.2"
+
 [features]
 default = ["std"]
 std = []

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,8 @@
+extern crate rustc_version;
+use rustc_version::{version, Version};
+
+fn main() {
+    if version().unwrap() >= Version::parse("1.26.0").unwrap() {
+        println!("cargo:rustc-cfg=rust_1_26");
+    }
+}

--- a/src/ctx.rs
+++ b/src/ctx.rs
@@ -290,7 +290,9 @@ ctx_impl!(u32, 4);
 ctx_impl!(i32, 4);
 ctx_impl!(u64, 8);
 ctx_impl!(i64, 8);
+#[cfg(rust_1_26)]
 ctx_impl!(u128, 16);
+#[cfg(rust_1_26)]
 ctx_impl!(i128, 16);
 
 macro_rules! from_ctx_float_impl {
@@ -335,7 +337,9 @@ into_ctx_impl!(u32, 4);
 into_ctx_impl!(i32, 4);
 into_ctx_impl!(u64, 8);
 into_ctx_impl!(i64, 8);
+#[cfg(rust_1_26)]
 into_ctx_impl!(u128, 16);
+#[cfg(rust_1_26)]
 into_ctx_impl!(i128, 16);
 
 macro_rules! into_ctx_float_impl {
@@ -473,7 +477,9 @@ sizeof_impl!(u32);
 sizeof_impl!(i32);
 sizeof_impl!(u64);
 sizeof_impl!(i64);
+#[cfg(rust_1_26)]
 sizeof_impl!(u128);
+#[cfg(rust_1_26)]
 sizeof_impl!(i128);
 sizeof_impl!(f32);
 sizeof_impl!(f64);


### PR DESCRIPTION
As discussed in https://github.com/m4b/scroll/issues/40, here's a PR which adds a build.rs that defines a rust_1_26 feature when compiled with Rust 1.26 or newer, and makes i128/u128 support conditional on that. This allows it to build with Rust 1.25.0.