### PR TITLE
Remove generic {Size,Units} in favor of usize

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,10 +194,9 @@ struct Data<'a> {
 // note the lifetime specified here
 impl<'a> ctx::TryFromCtx<'a, Endian> for Data<'a> {
   type Error = scroll::Error;
-  type Size = usize;
   // and the lifetime annotation on `&'a [u8]` here
   fn try_from_ctx (src: &'a [u8], endian: Endian)
-    -> Result<(Self, Self::Size), Self::Error> {
+    -> Result<(Self, usize), Self::Error> {
     let offset = &mut 0;
     let name = src.gread::<&str>(offset)?;
     let id = src.gread_with(offset, endian)?;

--- a/examples/data_ctx.rs
+++ b/examples/data_ctx.rs
@@ -10,9 +10,8 @@ struct Data<'a> {
 
 impl<'a> ctx::TryFromCtx<'a, Endian> for Data<'a> {
     type Error = scroll::Error;
-    type Size = usize;
     fn try_from_ctx (src: &'a [u8], endian: Endian)
-                     -> Result<(Self, Self::Size), Self::Error> {
+                     -> Result<(Self, usize), Self::Error> {
         let name = src.pread::<&'a str>(0)?;
         let id = src.pread_with(name.len()+1, endian)?;
         Ok((Data { name: name, id: id }, name.len()+4))

--- a/src/error.rs
+++ b/src/error.rs
@@ -8,12 +8,12 @@ use std::error;
 
 #[derive(Debug)]
 /// A custom Scroll error
-pub enum Error<T = usize> {
+pub enum Error {
     /// The type you tried to read was too big
-    TooBig { size: T, len: T },
+    TooBig { size: usize, len: usize },
     /// The requested offset to read/write at is invalid
-    BadOffset(T),
-    BadInput{ size: T, msg: &'static str },
+    BadOffset(usize),
+    BadInput{ size: usize, msg: &'static str },
     #[cfg(feature = "std")]
     /// A custom Scroll error for reporting messages to clients
     Custom(String),

--- a/src/leb128.rs
+++ b/src/leb128.rs
@@ -93,9 +93,8 @@ fn mask_continuation(byte: u8) -> u8 {
 
 impl<'a> TryFromCtx<'a> for Uleb128 {
     type Error = error::Error;
-    type Size = usize;
     #[inline]
-    fn try_from_ctx(src: &'a [u8], _ctx: ()) -> result::Result<(Self, Self::Size), Self::Error> {
+    fn try_from_ctx(src: &'a [u8], _ctx: ()) -> result::Result<(Self, usize), Self::Error> {
         use pread::Pread;
         let mut result = 0;
         let mut shift = 0;
@@ -122,9 +121,8 @@ impl<'a> TryFromCtx<'a> for Uleb128 {
 
 impl<'a> TryFromCtx<'a> for Sleb128 {
     type Error = error::Error;
-    type Size = usize;
     #[inline]
-    fn try_from_ctx(src: &'a [u8], _ctx: ()) -> result::Result<(Self, Self::Size), Self::Error> {
+    fn try_from_ctx(src: &'a [u8], _ctx: ()) -> result::Result<(Self, usize), Self::Error> {
         let o = 0;
         let offset = &mut 0;
         let mut result = 0;

--- a/src/lesser.rs
+++ b/src/lesser.rs
@@ -26,9 +26,8 @@ use ctx::{FromCtx, IntoCtx, SizeWith};
 /// }
 ///
 /// impl ctx::SizeWith<scroll::Endian> for Foo {
-///     type Units = usize;
 ///     // our parsing context doesn't influence our size
-///     fn size_with(_: &scroll::Endian) -> Self::Units {
+///     fn size_with(_: &scroll::Endian) -> usize {
 ///         ::std::mem::size_of::<Foo>()
 ///     }
 /// }
@@ -69,7 +68,7 @@ pub trait IOread<Ctx: Copy> : Read
     /// assert_eq!(0xefbe, beef);
     /// ```
     #[inline]
-    fn ioread<N: FromCtx<Ctx> + SizeWith<Ctx, Units = usize>>(&mut self) -> Result<N> where Ctx: Default {
+    fn ioread<N: FromCtx<Ctx> + SizeWith<Ctx>>(&mut self) -> Result<N> where Ctx: Default {
         let ctx = Ctx::default();
         self.ioread_with(ctx)
     }
@@ -95,7 +94,7 @@ pub trait IOread<Ctx: Copy> : Read
     /// assert_eq!(0xfeeddead, feeddead);
     /// ```
     #[inline]
-    fn ioread_with<N: FromCtx<Ctx> + SizeWith<Ctx, Units = usize>>(&mut self, ctx: Ctx) -> Result<N> {
+    fn ioread_with<N: FromCtx<Ctx> + SizeWith<Ctx>>(&mut self, ctx: Ctx) -> Result<N> {
         let mut scratch = [0u8; 256];
         let size = N::size_with(&ctx);
         let mut buf = &mut scratch[0..size];
@@ -133,7 +132,7 @@ pub trait IOwrite<Ctx: Copy>: Write
     /// assert_eq!(bytes.into_inner(), [0xde, 0xad, 0xbe, 0xef,]);
     /// ```
     #[inline]
-    fn iowrite<N: SizeWith<Ctx, Units = usize> + IntoCtx<Ctx>>(&mut self, n: N) -> Result<()> where Ctx: Default {
+    fn iowrite<N: SizeWith<Ctx> + IntoCtx<Ctx>>(&mut self, n: N) -> Result<()> where Ctx: Default {
         let ctx = Ctx::default();
         self.iowrite_with(n, ctx)
     }
@@ -155,7 +154,7 @@ pub trait IOwrite<Ctx: Copy>: Write
     /// assert_eq!(cursor.into_inner(), [0x68, 0x65, 0x6c, 0x6c, 0x6f, 0xde, 0xad, 0xbe, 0xef, 0x0]);
     /// ```
     #[inline]
-    fn iowrite_with<N: SizeWith<Ctx, Units = usize> + IntoCtx<Ctx>>(&mut self, n: N, ctx: Ctx) -> Result<()> {
+    fn iowrite_with<N: SizeWith<Ctx> + IntoCtx<Ctx>>(&mut self, n: N, ctx: Ctx) -> Result<()> {
         let mut buf = [0u8; 256];
         let size = N::size_with(&ctx);
         let buf = &mut buf[0..size];

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -117,10 +117,9 @@
 //! // note the lifetime specified here
 //! impl<'a> ctx::TryFromCtx<'a, Endian> for Data<'a> {
 //!   type Error = scroll::Error;
-//!   type Size = usize;
 //!   // and the lifetime annotation on `&'a [u8]` here
 //!   fn try_from_ctx (src: &'a [u8], endian: Endian)
-//!     -> Result<(Self, Self::Size), Self::Error> {
+//!     -> Result<(Self, usize), Self::Error> {
 //!     let offset = &mut 0;
 //!     let name = src.gread::<&str>(offset)?;
 //!     let id = src.gread_with(offset, endian)?;
@@ -350,8 +349,7 @@ mod tests {
 
     impl super::ctx::TryIntoCtx<super::Endian> for Foo {
         type Error = ExternalError;
-        type Size = usize;
-        fn try_into_ctx(self, this: &mut [u8], le: super::Endian) -> Result<Self::Size, Self::Error> {
+        fn try_into_ctx(self, this: &mut [u8], le: super::Endian) -> Result<usize, Self::Error> {
             use super::Pwrite;
             if this.len() < 2 { return Err((ExternalError {}).into()) }
             this.pwrite_with(self.0, 0, le)?;
@@ -361,8 +359,7 @@ mod tests {
 
     impl<'a> super::ctx::TryFromCtx<'a, super::Endian> for Foo {
         type Error = ExternalError;
-        type Size = usize;
-        fn try_from_ctx(this: &'a [u8], le: super::Endian) -> Result<(Self, Self::Size), Self::Error> {
+        fn try_from_ctx(this: &'a [u8], le: super::Endian) -> Result<(Self, usize), Self::Error> {
             use super::Pread;
             if this.len() > 2 { return Err((ExternalError {}).into()) }
             let n = this.pread_with(0, le)?;

--- a/src/pread.rs
+++ b/src/pread.rs
@@ -1,5 +1,5 @@
 use core::result;
-use core::ops::{Index, RangeFrom, Add, AddAssign};
+use core::ops::{Index, RangeFrom};
 
 use ctx::{TryFromCtx, MeasureWith};
 use error;
@@ -18,8 +18,7 @@ use error;
 ///
 /// impl<'a> ctx::TryFromCtx<'a, scroll::Endian> for Foo {
 ///      type Error = scroll::Error;
-///      type Size = usize;
-///      fn try_from_ctx(this: &'a [u8], le: scroll::Endian) -> Result<(Self, Self::Size), Self::Error> {
+///      fn try_from_ctx(this: &'a [u8], le: scroll::Endian) -> Result<(Self, usize), Self::Error> {
 ///          if this.len() < 2 { return Err((scroll::Error::Custom("whatever".to_string())).into()) }
 ///          let n = this.pread_with(0, le)?;
 ///          Ok((Foo(n), 2))
@@ -68,8 +67,7 @@ use error;
 ///
 ///  impl<'a> ctx::TryFromCtx<'a, scroll::Endian> for Foo {
 ///      type Error = ExternalError;
-///      type Size = usize;
-///      fn try_from_ctx(this: &'a [u8], le: scroll::Endian) -> Result<(Self, Self::Size), Self::Error> {
+///      fn try_from_ctx(this: &'a [u8], le: scroll::Endian) -> Result<(Self, usize), Self::Error> {
 ///          if this.len() <= 2 { return Err((ExternalError {}).into()) }
 ///          let offset = &mut 0;
 ///          let n = this.gread_with(offset, le)?;
@@ -80,11 +78,10 @@ use error;
 /// let bytes: [u8; 4] = [0xde, 0xad, 0, 0];
 /// let foo: Result<Foo, ExternalError> = bytes.pread(0);
 /// ```
-pub trait Pread<Ctx, E, I = usize> : Index<I> + Index<RangeFrom<I>> + MeasureWith<Ctx, Units = I>
+pub trait Pread<Ctx, E> : Index<usize> + Index<RangeFrom<usize>> + MeasureWith<Ctx>
  where
        Ctx: Copy,
-       I: Add + Copy + PartialOrd,
-       E: From<error::Error<I>>,
+       E: From<error::Error>,
 {
     #[inline]
     /// Reads a value from `self` at `offset` with a default `Ctx`. For the primitive numeric values, this will read at the machine's endianness.
@@ -93,7 +90,7 @@ pub trait Pread<Ctx, E, I = usize> : Index<I> + Index<RangeFrom<I>> + MeasureWit
     /// use scroll::Pread;
     /// let bytes = [0x7fu8; 0x01];
     /// let byte = bytes.pread::<u8>(0).unwrap();
-    fn pread<'a, N: TryFromCtx<'a, Ctx, <Self as Index<RangeFrom<I>>>::Output, Error = E, Size = I>>(&'a self, offset: I) -> result::Result<N, E> where <Self as Index<RangeFrom<I>>>::Output: 'a, Ctx: Default {
+    fn pread<'a, N: TryFromCtx<'a, Ctx, <Self as Index<RangeFrom<usize>>>::Output, Error = E>>(&'a self, offset: usize) -> result::Result<N, E> where <Self as Index<RangeFrom<usize>>>::Output: 'a, Ctx: Default {
         self.pread_with(offset, Ctx::default())
     }
     #[inline]
@@ -104,7 +101,7 @@ pub trait Pread<Ctx, E, I = usize> : Index<I> + Index<RangeFrom<I>> + MeasureWit
     /// let bytes: [u8; 2] = [0xde, 0xad];
     /// let dead: u16 = bytes.pread_with(0, scroll::BE).unwrap();
     /// assert_eq!(dead, 0xdeadu16);
-    fn pread_with<'a, N: TryFromCtx<'a, Ctx, <Self as Index<RangeFrom<I>>>::Output, Error = E, Size = I>>(&'a self, offset: I, ctx: Ctx) -> result::Result<N, E> where <Self as Index<RangeFrom<I>>>::Output: 'a {
+    fn pread_with<'a, N: TryFromCtx<'a, Ctx, <Self as Index<RangeFrom<usize>>>::Output, Error = E>>(&'a self, offset: usize, ctx: Ctx) -> result::Result<N, E> where <Self as Index<RangeFrom<usize>>>::Output: 'a {
         let len = self.measure_with(&ctx);
         if offset >= len {
             return Err(error::Error::BadOffset(offset).into())
@@ -120,7 +117,7 @@ pub trait Pread<Ctx, E, I = usize> : Index<I> + Index<RangeFrom<I>> + MeasureWit
     /// let bytes = [0x7fu8; 0x01];
     /// let byte = bytes.gread::<u8>(offset).unwrap();
     /// assert_eq!(*offset, 1);
-    fn gread<'a, N: TryFromCtx<'a, Ctx, <Self as Index<RangeFrom<I>>>::Output, Error = E, Size = I>>(&'a self, offset: &mut I) -> result::Result<N, E> where I: AddAssign, Ctx: Default, <Self as Index<RangeFrom<I>>>::Output: 'a {
+    fn gread<'a, N: TryFromCtx<'a, Ctx, <Self as Index<RangeFrom<usize>>>::Output, Error = E>>(&'a self, offset: &mut usize) -> result::Result<N, E> where Ctx: Default, <Self as Index<RangeFrom<usize>>>::Output: 'a {
         let ctx = Ctx::default();
         self.gread_with(offset, ctx)
     }
@@ -134,10 +131,10 @@ pub trait Pread<Ctx, E, I = usize> : Index<I> + Index<RangeFrom<I>> + MeasureWit
     /// assert_eq!(dead, 0xdeadu16);
     /// assert_eq!(*offset, 2);
     #[inline]
-    fn gread_with<'a, N: TryFromCtx<'a, Ctx, <Self as Index<RangeFrom<I>>>::Output, Error = E, Size = I>>
-        (&'a self, offset: &mut I, ctx: Ctx) ->
+    fn gread_with<'a, N: TryFromCtx<'a, Ctx, <Self as Index<RangeFrom<usize>>>::Output, Error = E>>
+        (&'a self, offset: &mut usize, ctx: Ctx) ->
         result::Result<N, E>
-        where I: AddAssign, <Self as Index<RangeFrom<I>>>::Output: 'a
+        where <Self as Index<RangeFrom<usize>>>::Output: 'a
     {
         let o = *offset;
         // self.pread_with(o, ctx).and_then(|(n, size)| {
@@ -165,12 +162,11 @@ pub trait Pread<Ctx, E, I = usize> : Index<I> + Index<RangeFrom<I>> + MeasureWit
     /// assert_eq!(&bytes, &bytes_from);
     /// assert_eq!(*offset, 2);
     #[inline]
-    fn gread_inout<'a, N>(&'a self, offset: &mut I, inout: &mut [N]) -> result::Result<(), E>
+    fn gread_inout<'a, N>(&'a self, offset: &mut usize, inout: &mut [N]) -> result::Result<(), E>
         where
-        I: AddAssign,
-        N: TryFromCtx<'a, Ctx, <Self as Index<RangeFrom<I>>>::Output, Error = E, Size = I>,
+        N: TryFromCtx<'a, Ctx, <Self as Index<RangeFrom<usize>>>::Output, Error = E>,
     Ctx: Default,
-    <Self as Index<RangeFrom<I>>>::Output: 'a
+    <Self as Index<RangeFrom<usize>>>::Output: 'a
     {
         for i in inout.iter_mut() {
             *i = self.gread(offset)?;
@@ -189,11 +185,10 @@ pub trait Pread<Ctx, E, I = usize> : Index<I> + Index<RangeFrom<I>> + MeasureWit
     /// assert_eq!(&bytes, &bytes_from);
     /// assert_eq!(*offset, 2);
     #[inline]
-    fn gread_inout_with<'a, N>(&'a self, offset: &mut I, inout: &mut [N], ctx: Ctx) -> result::Result<(), E>
+    fn gread_inout_with<'a, N>(&'a self, offset: &mut usize, inout: &mut [N], ctx: Ctx) -> result::Result<(), E>
         where
-        I: AddAssign,
-        N: TryFromCtx<'a, Ctx, <Self as Index<RangeFrom<I>>>::Output, Error = E, Size = I>,
-    <Self as Index<RangeFrom<I>>>::Output: 'a
+        N: TryFromCtx<'a, Ctx, <Self as Index<RangeFrom<usize>>>::Output, Error = E>,
+    <Self as Index<RangeFrom<usize>>>::Output: 'a
     {
         for i in inout.iter_mut() {
             *i = self.gread_with(offset, ctx)?;
@@ -203,7 +198,6 @@ pub trait Pread<Ctx, E, I = usize> : Index<I> + Index<RangeFrom<I>> + MeasureWit
 }
 
 impl<Ctx: Copy,
-     I: Add + Copy + PartialOrd,
-     E: From<error::Error<I>>,
-     R: ?Sized + Index<I> + Index<RangeFrom<I>> + MeasureWith<Ctx, Units = I>>
-    Pread<Ctx, E, I> for R {}
+     E: From<error::Error>,
+     R: ?Sized + Index<usize> + Index<RangeFrom<usize>> + MeasureWith<Ctx>>
+    Pread<Ctx, E> for R {}

--- a/src/pwrite.rs
+++ b/src/pwrite.rs
@@ -1,5 +1,5 @@
 use core::result;
-use core::ops::{Index, IndexMut, RangeFrom, Add, AddAssign};
+use core::ops::{Index, IndexMut, RangeFrom};
 
 use ctx::{TryIntoCtx, MeasureWith};
 use error;
@@ -17,9 +17,8 @@ use error;
 /// impl ctx::TryIntoCtx<Endian> for Foo {
 ///     // you can use your own error here too, but you will then need to specify it in fn generic parameters
 ///     type Error = scroll::Error;
-///     type Size = usize;
 ///     // you can write using your own context too... see `leb128.rs`
-///     fn try_into_ctx(self, this: &mut [u8], le: Endian) -> Result<Self::Size, Self::Error> {
+///     fn try_into_ctx(self, this: &mut [u8], le: Endian) -> Result<usize, Self::Error> {
 ///         if this.len() < 2 { return Err((scroll::Error::Custom("whatever".to_string())).into()) }
 ///         this.pwrite_with(self.0, 0, le)?;
 ///         Ok(2)
@@ -30,13 +29,12 @@ use error;
 /// let mut bytes: [u8; 4] = [0, 0, 0, 0];
 /// bytes.pwrite_with(Foo(0x7f), 1, LE).unwrap();
 ///
-pub trait Pwrite<Ctx, E, I = usize> : Index<I> + IndexMut<RangeFrom<I>> + MeasureWith<Ctx, Units = I>
+pub trait Pwrite<Ctx, E> : Index<usize> + IndexMut<RangeFrom<usize>> + MeasureWith<Ctx>
  where
        Ctx: Copy,
-       I: Add + Copy + PartialOrd,
-       E: From<error::Error<I>>,
+       E: From<error::Error>,
 {
-    fn pwrite<N: TryIntoCtx<Ctx, <Self as Index<RangeFrom<I>>>::Output, Error = E, Size = I>>(&mut self, n: N, offset: I) -> result::Result<I, E> where Ctx: Default {
+    fn pwrite<N: TryIntoCtx<Ctx, <Self as Index<RangeFrom<usize>>>::Output, Error = E>>(&mut self, n: N, offset: usize) -> result::Result<usize, E> where Ctx: Default {
         self.pwrite_with(n, offset, Ctx::default())
     }
     /// Write `N` at offset `I` with context `Ctx`
@@ -46,7 +44,7 @@ pub trait Pwrite<Ctx, E, I = usize> : Index<I> + IndexMut<RangeFrom<I>> + Measur
     /// let mut bytes: [u8; 8] = [0, 0, 0, 0, 0, 0, 0, 0];
     /// bytes.pwrite_with::<u32>(0xbeefbeef, 0, LE).unwrap();
     /// assert_eq!(bytes.pread_with::<u32>(0, LE).unwrap(), 0xbeefbeef);
-    fn pwrite_with<N: TryIntoCtx<Ctx, <Self as Index<RangeFrom<I>>>::Output, Error = E, Size = I>>(&mut self, n: N, offset: I, ctx: Ctx) -> result::Result<I, E> {
+    fn pwrite_with<N: TryIntoCtx<Ctx, <Self as Index<RangeFrom<usize>>>::Output, Error = E>>(&mut self, n: N, offset: usize, ctx: Ctx) -> result::Result<usize, E> {
         let len = self.measure_with(&ctx);
         if offset >= len {
             return Err(error::Error::BadOffset(offset).into())
@@ -56,17 +54,14 @@ pub trait Pwrite<Ctx, E, I = usize> : Index<I> + IndexMut<RangeFrom<I>> + Measur
     }
     /// Write `n` into `self` at `offset`, with a default `Ctx`. Updates the offset.
     #[inline]
-    fn gwrite<N: TryIntoCtx<Ctx, <Self as Index<RangeFrom<I>>>::Output,  Error = E, Size = I>>(&mut self, n: N, offset: &mut I) -> result::Result<I, E> where
-        I: AddAssign,
+    fn gwrite<N: TryIntoCtx<Ctx, <Self as Index<RangeFrom<usize>>>::Output, Error = E>>(&mut self, n: N, offset: &mut usize) -> result::Result<usize, E> where
         Ctx: Default {
         let ctx = Ctx::default();
         self.gwrite_with(n, offset, ctx)
     }
     /// Write `n` into `self` at `offset`, with the `ctx`. Updates the offset.
     #[inline]
-    fn gwrite_with<N: TryIntoCtx<Ctx, <Self as Index<RangeFrom<I>>>::Output, Error = E, Size = I>>(&mut self, n: N, offset: &mut I, ctx: Ctx) -> result::Result<I, E>
-        where I: AddAssign,
-    {
+    fn gwrite_with<N: TryIntoCtx<Ctx, <Self as Index<RangeFrom<usize>>>::Output, Error = E>>(&mut self, n: N, offset: &mut usize, ctx: Ctx) -> result::Result<usize, E> {
         let o = *offset;
         match self.pwrite_with(n, o, ctx) {
             Ok(size) => {
@@ -79,7 +74,6 @@ pub trait Pwrite<Ctx, E, I = usize> : Index<I> + IndexMut<RangeFrom<I>> + Measur
 }
 
 impl<Ctx: Copy,
-     I: Add + Copy + PartialOrd,
-     E: From<error::Error<I>>,
-     R: ?Sized + Index<I> + IndexMut<RangeFrom<I>> + MeasureWith<Ctx, Units = I>>
-    Pwrite<Ctx, E, I> for R {}
+     E: From<error::Error>,
+     R: ?Sized + Index<usize> + IndexMut<RangeFrom<usize>> + MeasureWith<Ctx>>
+    Pwrite<Ctx, E> for R {}

--- a/tests/api.rs
+++ b/tests/api.rs
@@ -35,7 +35,6 @@ impl<'a> Section<'a> {
 }
 
 impl<'a> ctx::SizeWith for Section<'a> {
-    type Units = usize;
     fn size_with(_ctx: &()) -> usize {
         4
     }
@@ -61,8 +60,7 @@ pub struct Section32 {
 
 impl<'a> ctx::TryFromCtx<'a, ()> for Section<'a> {
     type Error = scroll::Error;
-    type Size = usize;
-    fn try_from_ctx(_bytes: &'a [u8], _ctx: ()) -> ::std::result::Result<(Self, Self::Size), Self::Error> {
+    fn try_from_ctx(_bytes: &'a [u8], _ctx: ()) -> ::std::result::Result<(Self, usize), Self::Error> {
         //let section = Section::from_ctx(bytes, bytes.pread_with::<Section32>(offset, ctx)?);
         let section = unsafe { ::std::mem::uninitialized::<Section>()};
         Ok((section, ::std::mem::size_of::<Section>()))
@@ -106,7 +104,6 @@ impl<'a> Segment<'a> {
 }
 
 impl<'a> ctx::SizeWith for Segment<'a> {
-    type Units = usize;
     fn size_with(_ctx: &()) -> usize {
         4
     }
@@ -186,8 +183,7 @@ impl scroll::ctx::FromCtx<scroll::Endian> for Foo {
 }
 
 impl scroll::ctx::SizeWith<scroll::Endian> for Foo {
-    type Units = usize;
-    fn size_with(_: &scroll::Endian) -> Self::Units {
+    fn size_with(_: &scroll::Endian) -> usize {
         ::std::mem::size_of::<Foo>()
     }
 }


### PR DESCRIPTION
This PR addresses https://github.com/m4b/scroll/issues/37, globally squishing `{Size,Units}` into `usize`. This is a breaking change which warrants careful consideration, but… tests pass.

Corresponding `scroll_derive` PR: https://github.com/m4b/scroll_derive/pull/19