### PR TITLE
Restructuring the documentation

### DIFF
--- a/src/ctx.rs
+++ b/src/ctx.rs
@@ -1,23 +1,23 @@
 //! Generic context-aware conversion traits, for automatic _downstream_ extension of `Pread`, et. al
 //!
 //! The context traits are arguably the center piece of the scroll crate. In simple terms they
-//! define how to actually read respectively write a data type from a container, being able to
+//! define how to actually read and write, respectively, a data type from a container, being able to
 //! take context into account.
 //!
 //! ### Reading
 //!
-//! Types implementing [TryFromCtx](trait.TryFromCtx.html) and it's infallible cousing [FromCtx](trait.FromCtx.html)
-//! allow an user of [Pread::pread](../trait.Pread.html#method.pread) or respectively
+//! Types implementing [TryFromCtx](trait.TryFromCtx.html) and it's infallible cousin [FromCtx](trait.FromCtx.html)
+//! allow a user of [Pread::pread](../trait.Pread.html#method.pread) or respectively
 //! [Cread::cread](../trait.Cread.html#method.cread) and
 //! [IOread::ioread](../trait.IOread.html#method.ioread) to read that data type from a data source one
-//! of `*read` traits has been implemented for.
+//! of the `*read` traits has been implemented for.
 //! 
 //! Implementations of `TryFromCtx` specify a source (called `This`) and an `Error` type for failed
 //! reads. The source defines the kind of container the type can be read from, and defaults to
-//! `[u8]` respetively any type that implements `AsRef<[u8]>`.
+//! `[u8]` for any type that implements `AsRef<[u8]>`.
 //!
 //! `FromCtx` is slightly more restricted; it requires the implementer to use `[u8]` as source and
-//! not fail, thus does not allow for an `Error` type.
+//! never fail, and thus does not have an `Error` type.
 //!
 //! Types chosen here are of relevance to `Pread` implementations; of course only a container which
 //! can produce a source of the type `This` can be used to read a `TryFromCtx` requiring it and the
@@ -28,8 +28,8 @@
 //! [TryIntoCtx](trait.TryIntoCtx.html) and the infallible [IntoCtx](trait.IntoCtx.html) work
 //! similarly to the above traits, allowing [Pwrite::pwrite](../trait.Pwrite.html#method.pwrite) or
 //! respectively [Cwrite::cwrite](../trait.Cwrite.html#method.cwrite) and
-//! [IOwrite::iowrite](../trait.IOwrite.html#method.iowrite) to write data into a byte sink on of
-//! the `*write` traits has been implemented for.
+//! [IOwrite::iowrite](../trait.IOwrite.html#method.iowrite) to write data into a byte sink for
+//! which one of the `*write` traits has been implemented for.
 //!
 //! `IntoCtx` is similarly restricted as `FromCtx` is to `TryFromCtx`. And equally the types chosen
 //! affect usable `Pwrite` implementation.
@@ -261,7 +261,7 @@ pub trait FromCtx<Ctx: Copy = (), This: ?Sized = [u8]> {
 ///
 /// # Implementing Your Own Reader
 /// If you want to implement your own reader for a type `Foo` from some kind of buffer (say
-/// `[u8]`), then you need to implement
+/// `[u8]`), then you need to implement this trait
 ///
 /// ```rust
 /// use scroll::{self, ctx, Pread};
@@ -290,7 +290,7 @@ pub trait FromCtx<Ctx: Copy = (), This: ?Sized = [u8]> {
 ///  use scroll::{self, ctx, Pread};
 ///  use std::error;
 ///  use std::fmt::{self, Display};
-///  // make some kind of normal error which also can transform a scroll error ideally (quick_error, error_chain allow this automatically nowadays)
+///  // make some kind of normal error which also can transformed from a scroll error
 ///  #[derive(Debug)]
 ///  pub struct ExternalError {}
 ///
@@ -348,11 +348,11 @@ pub trait IntoCtx<Ctx: Copy = (), This: ?Sized = [u8]>: Sized {
 /// #[derive(Debug, PartialEq, Eq)]
 /// pub struct Foo(u16);
 ///
-/// // this will use the default `DefaultCtx = scroll::Endian` and `I = usize`...
+/// // this will use the default `DefaultCtx = scroll::Endian`
 /// impl ctx::TryIntoCtx<Endian> for Foo {
 ///     // you can use your own error here too, but you will then need to specify it in fn generic parameters
 ///     type Error = scroll::Error;
-///     // you can write using your own context too... see `leb128.rs`
+///     // you can write using your own context type, see `leb128.rs`
 ///     fn try_into_ctx(self, this: &mut [u8], le: Endian) -> Result<usize, Self::Error> {
 ///         if this.len() < 2 { return Err((scroll::Error::Custom("whatever".to_string())).into()) }
 ///         this.pwrite_with(self.0, 0, le)?;

--- a/src/greater.rs
+++ b/src/greater.rs
@@ -2,7 +2,8 @@ use core::ops::{Index, IndexMut, RangeFrom};
 
 use crate::ctx::{FromCtx, IntoCtx};
 
-/// Core-read - core, no_std friendly trait for reading basic traits from byte buffers. Cannot fail unless the buffer is too small, in which case an assert fires and the program panics.
+/// Core-read - core, no_std friendly trait for reading basic traits from byte buffers. Cannot fail
+/// unless the buffer is too small, in which case an assert fires and the program panics.
 ///
 /// If your type implements [FromCtx](ctx/trait.FromCtx.html) then you can `cread::<YourType>(offset)`.
 ///
@@ -86,8 +87,10 @@ pub trait Cread<Ctx, I = usize> : Index<I> + Index<RangeFrom<I>>
 
 impl<Ctx: Copy, I, R: ?Sized + Index<I> + Index<RangeFrom<I>>> Cread<Ctx, I> for R {}
 
-/// Core-write - core, no_std friendly trait for writing basic types into byte buffers. Cannot fail unless the buffer is too small, in which case an assert fires and the program panics.
-/// Similar to [Cread](trait.Cread.html), if your type implements [IntoCtx](ctx/trait.IntoCtx.html) then you can `cwrite(your_type, offset)`.
+/// Core-write - core, no_std friendly trait for writing basic types into byte buffers. Cannot fail
+/// unless the buffer is too small, in which case an assert fires and the program panics.
+/// Similar to [Cread](trait.Cread.html), if your type implements [IntoCtx](ctx/trait.IntoCtx.html)
+/// then you can `cwrite(your_type, offset)`.
 ///
 /// # Example
 ///

--- a/src/lesser.rs
+++ b/src/lesser.rs
@@ -1,12 +1,17 @@
 use std::io::{Result, Read, Write};
 use crate::ctx::{FromCtx, IntoCtx, SizeWith};
 
-/// An extension trait to `std::io::Read` streams; this only deserializes simple types, like `u8`, `i32`, `f32`, `usize`, etc.
+/// An extension trait to `std::io::Read` streams; mainly targeted at reading known-size primitive
+/// types. 
 ///
-/// If you implement [`FromCtx`](ctx/trait.FromCtx.html) and [`SizeWith`](ctx/trait.SizeWith.html) for your type, you can then `ioread::<YourType>()` on a `Read`.  Note: [`FromCtx`](ctx/trait.FromCtx.html) is only meant for very simple types, and should _never_ fail.
+/// Requires types to implement [`FromCtx`](ctx/trait.FromCtx.html) and [`SizeWith`](ctx/trait.SizeWith.html).
 ///
-/// **NB** You should probably add `repr(packed)` or `repr(C)` and be very careful how you implement [`SizeWith`](ctx/trait.SizeWith.html), otherwise you
-/// will get IO errors failing to fill entire buffer (the size you specified in `SizeWith`), or out of bound errors (depending on your impl) in `from_ctx`
+/// **NB** You should probably add `repr(packed)` or `repr(C)` and be very careful how you
+/// implement [`SizeWith`](ctx/trait.SizeWith.html), otherwise you will get IO errors failing to
+/// fill entire buffer (the size you specified in `SizeWith`), or out of bound errors (depending on
+/// your impl) in `from_ctx`
+///
+/// Warning: Currently ioread/write uses a small 256-byte buffer and can not read/write larger types
 ///
 /// # Example
 /// ```rust

--- a/src/lesser.rs
+++ b/src/lesser.rs
@@ -1,15 +1,15 @@
 use std::io::{Result, Read, Write};
 use crate::ctx::{FromCtx, IntoCtx, SizeWith};
 
-/// An extension trait to `std::io::Read` streams; mainly targeted at reading known-size primitive
-/// types. 
+/// An extension trait to `std::io::Read` streams; mainly targeted at reading primitive types with
+/// a known size.
 ///
 /// Requires types to implement [`FromCtx`](ctx/trait.FromCtx.html) and [`SizeWith`](ctx/trait.SizeWith.html).
 ///
-/// **NB** You should probably add `repr(packed)` or `repr(C)` and be very careful how you
-/// implement [`SizeWith`](ctx/trait.SizeWith.html), otherwise you will get IO errors failing to
-/// fill entire buffer (the size you specified in `SizeWith`), or out of bound errors (depending on
-/// your impl) in `from_ctx`
+/// **NB** You should probably add `repr(C)` and be very careful how you implement
+/// [`SizeWith`](ctx/trait.SizeWith.html), otherwise you will get IO errors failing to fill entire
+/// buffer (the size you specified in `SizeWith`), or out of bound errors (depending on your impl)
+/// in `from_ctx`.
 ///
 /// Warning: Currently ioread/write uses a small 256-byte buffer and can not read/write larger types
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,9 +19,10 @@
 //!
 //! Scroll sets down a number of traits:
 //!
-//! [FromCtx](ctx/trait.FromCtx.html), [IntoCtx](ctx/trait.IntoCtx.html) and
-//! [TryFromCtx](ctx/trait.TryFromCtx.html); to be implemented on custom types to allow reading,
-//! writing, and potentially fallible reading respectively.
+//! [FromCtx](ctx/trait.FromCtx.html), [IntoCtx](ctx/trait.IntoCtx.html),
+//! [TryFromCtx](ctx/trait.TryFromCtx.html) and [TryIntoCtx](ctx/trait.TryIntoCtx.html) — further
+//! explained in the [ctx module](ctx/index.html); to be implemented on custom types to allow
+//! reading, writing, and potentially fallible reading/writing respectively.
 //!
 //! [Pread](trait.Pread.html) and [Pwrite](trait.Pwrite.html) which are implemented on data
 //! containers such as byte arrays to define how to read or respectively write types implementing
@@ -159,6 +160,7 @@
 //!
 //! // Our custom context type. In a more complex situation you could for example store details on
 //! // how to write or read your type, field-sizes or other information.
+//! // In this simple example we could also do without using a custom context in the first place.
 //! #[derive(Copy, Clone)]
 //! struct Context(Endian);
 //!
@@ -193,9 +195,9 @@
 //!   }
 //! }
 //!
-//! // In lieu of a complex byte buffer we hearken back to the venerable &[u8]; do note however
-//! // that the implementation of TryFromCtx did not specify such. In fact any type that implements
-//! // Pread can now read `Data` as it implements TryFromCtx.
+//! // In lieu of a complex byte buffer we hearken back to a simple &[u8]; the default source
+//! // of TryFromCtx. However, any type that implements Pread to produce a &[u8] can now read
+//! // `Data` thanks to it's implementation of TryFromCtx.
 //! let bytes = b"\x01\x02\x03\x04\x00\x08UserName";
 //! let data: Data = bytes.pread_with(0, Context(Endian::Big)).unwrap();
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -97,6 +97,8 @@
 //! assert_eq!("hello world", hello_world);
 //!
 //! // We can again provide a custom context; for example to parse Space-delimited strings.
+//! // As you can see while we still call `pread` changing the context can influence the output —
+//! // instead of splitting at '\0' we split at spaces
 //! let hello2: &[u8] = b"hello world\0more words";
 //! let world: &str = hello2.pread_with(6, ctx::StrCtx::Delimiter(ctx::SPACE)).unwrap();
 //! assert_eq!("world\0more", world);

--- a/src/pread.rs
+++ b/src/pread.rs
@@ -4,80 +4,44 @@ use core::ops::{Index, RangeFrom};
 use crate::ctx::{TryFromCtx, MeasureWith};
 use crate::error;
 
-/// A very generic, contextual pread interface in Rust. Allows completely parallelized reads, as `Self` is immutable
+/// A very generic, contextual pread interface in Rust. 
 ///
-/// Don't be scared! The `Pread` definition _is_ terrifying, but it is definitely tractable. Essentially, `E` is the error, `Ctx` the parsing context, `I` is the indexing type, `TryCtx` is the "offset + ctx" Context given to the `TryFromCtx` trait bounds, and `SliceCtx` is the "offset + size + ctx" context given to the `TryRefFromCtx` trait bound.
+/// Like [Pwrite](trait.Pwrite.html) — but for reading!
 ///
-/// # Implementing Your Own Reader
-/// If you want to implement your own reader for a type `Foo` from some kind of buffer (say `[u8]`), then you need to implement [TryFromCtx](trait.TryFromCtx.html)
+/// Implementing `Pread` on a data store allows you to then read almost arbitrarily complex types
+/// efficiently.
 ///
-/// ```rust
-/// use scroll::{self, ctx, Pread};
-/// #[derive(Debug, PartialEq, Eq)]
-/// pub struct Foo(u16);
+/// To this end the Pread trait works in conjuction with the [TryFromCtx](ctx/trait.TryFromCtx.html);
+/// The `TryFromCtx` trait implemented on a type defines how to convert data to an object of that
+/// type, the Pread trait implemented on a data store defines how to extract said data from that
+/// store.
 ///
-/// impl<'a> ctx::TryFromCtx<'a, scroll::Endian> for Foo {
-///      type Error = scroll::Error;
-///      fn try_from_ctx(this: &'a [u8], le: scroll::Endian) -> Result<(Self, usize), Self::Error> {
-///          if this.len() < 2 { return Err((scroll::Error::Custom("whatever".to_string())).into()) }
-///          let n = this.pread_with(0, le)?;
-///          Ok((Foo(n), 2))
-///      }
-/// }
+/// It should be noted though that in this context, data does not necessarily mean `&[u8]` —
+/// `Pread` and `TryFromCtx` are generic over what 'data' means and could be implemented instead
+/// over chunks of memory or any other indexable type — but scroll does come with a set of powerful
+/// blanket implementations for data being a continous block of byte-addressable memory.
 ///
-/// let bytes: [u8; 4] = [0xde, 0xad, 0, 0];
-/// let foo = bytes.pread_with::<Foo>(0, scroll::LE).unwrap();
-/// assert_eq!(Foo(0xadde), foo);
+/// Pread provides two main groups of functions: pread and gread.
 ///
-/// let foo2 = bytes.pread_with::<Foo>(0, scroll::BE).unwrap();
-/// assert_eq!(Foo(0xdeadu16), foo2);
-/// ```
+/// `pread` is the basic function that simply extracts a given type from a given data store - either
+/// using a provided Context in the case of [pread_with](trait.Pread.html#method.pread_with) or
+/// with the default context for the given type in the case of [pread](trait.Pread.html#method.pread)
 ///
-/// # Advanced: Using Your Own Error in `TryFromCtx`
-/// ```rust
-///  use scroll::{self, ctx, Pread};
-///  use std::error;
-///  use std::fmt::{self, Display};
-///  // make some kind of normal error which also can transform a scroll error ideally (quick_error, error_chain allow this automatically nowadays)
-///  #[derive(Debug)]
-///  pub struct ExternalError {}
+/// `gread` does in addition to that update the offset it's currently at, allowing for a cursored
+/// read — `gread_inout` expands on that and reads a number of continous types from the data store.
+/// gread again comes with `_with` variants to allow using a specific context.
 ///
-///  impl Display for ExternalError {
-///      fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-///          write!(fmt, "ExternalError")
-///      }
-///  }
+/// Since pread and friends are very generic functions their types are rather complex, but very
+/// much understandable; `TryFromCtx` is generic over `Ctx` ([described
+/// here](ctx/index.html#context)), `Output` and `Error`. The Error type is hopefully
+/// self-explanatory, however the `Output` type is rather important; it defines what Pread extracts
+/// from the data store and has to match up with what `TryFromCtx` expects as input to convert into
+/// the resulting type. scroll defaults to `&[u8]` here.
 ///
-///  impl error::Error for ExternalError {
-///      fn description(&self) -> &str {
-///          "ExternalError"
-///      }
-///      fn cause(&self) -> Option<&error::Error> { None}
-///  }
+/// Unless you need to implement your own data store — that is either can't convert to `&[u8]` or
+/// have a data that is not `&[u8]` — you will probably want to implement
+/// [TryFromCtx](ctx/trait.TryFromCtx.html) on your Rust types to be extracted.
 ///
-///  impl From<scroll::Error> for ExternalError {
-///      fn from(err: scroll::Error) -> Self {
-///          match err {
-///              _ => ExternalError{},
-///          }
-///      }
-///  }
-///  #[derive(Debug, PartialEq, Eq)]
-///  pub struct Foo(u16);
-///
-///  impl<'a> ctx::TryFromCtx<'a, scroll::Endian> for Foo {
-///      type Error = ExternalError;
-///      fn try_from_ctx(this: &'a [u8], le: scroll::Endian) -> Result<(Self, usize), Self::Error> {
-///          if this.len() <= 2 { return Err((ExternalError {}).into()) }
-///          let offset = &mut 0;
-///          let n = this.gread_with(offset, le)?;
-///          Ok((Foo(n), *offset))
-///      }
-///  }
-///
-/// let bytes: [u8; 4] = [0xde, 0xad, 0, 0];
-/// let foo: Result<Foo, ExternalError> = bytes.pread(0);
-/// ```
 pub trait Pread<Ctx, E> : Index<usize> + Index<RangeFrom<usize>> + MeasureWith<Ctx>
  where
        Ctx: Copy,


### PR DESCRIPTION
I've recently started working with scroll and found the documentation somewhat hard to follow.

Since complaining about cool stuff I get for free (which this library definitely qualifies for) isn't all that nice I'm trying to improve the docs and structure them to be easier to follow for would-be users.

Please don't merge this PR yet; since I only just started using the library I may be wrong about some details of how stuff works; I'm mostly opening this PR to allow for easier comments and criticism on what I'm writing.

This PR will also fix #60 and fix #67 when done.