### PR TITLE
Pread/Pwrite redefinitions

### DIFF
--- a/src/pwrite.rs
+++ b/src/pwrite.rs
@@ -1,7 +1,6 @@
-use core::ops::{Index, IndexMut, RangeFrom};
 use core::result;
 
-use crate::ctx::{MeasureWith, TryIntoCtx};
+use crate::ctx::TryIntoCtx;
 use crate::error;
 
 /// A very generic, contextual pwrite interface in Rust.
@@ -21,15 +20,12 @@ use crate::error;
 /// should read the documentation of `Pread` first.
 ///
 /// Unless you need to implement your own data store — that is either can't convert to `&[u8]` or
-/// have a data that is not `&[u8]` — you will probably want to implement
+/// have a data that does not expose a `&mut [u8]` — you will probably want to implement
 /// [TryIntoCtx](ctx/trait.TryIntoCtx.html) on your Rust types to be written.
 ///
-pub trait Pwrite<Ctx, E>: Index<usize> + IndexMut<RangeFrom<usize>> + MeasureWith<Ctx>
-where
-    Ctx: Copy,
-    E: From<error::Error>,
-{
-    fn pwrite<N: TryIntoCtx<Ctx, <Self as Index<RangeFrom<usize>>>::Output, Error = E>>(
+pub trait Pwrite<Ctx: Copy, E> {
+    #[inline]
+    fn pwrite<N: TryIntoCtx<Ctx, Self, Error = E>>(
         &mut self,
         n: N,
         offset: usize,
@@ -39,6 +35,7 @@ where
     {
         self.pwrite_with(n, offset, Ctx::default())
     }
+
     /// Write `N` at offset `I` with context `Ctx`
     /// # Example
     /// ```
@@ -46,22 +43,16 @@ where
     /// let mut bytes: [u8; 8] = [0, 0, 0, 0, 0, 0, 0, 0];
     /// bytes.pwrite_with::<u32>(0xbeefbeef, 0, LE).unwrap();
     /// assert_eq!(bytes.pread_with::<u32>(0, LE).unwrap(), 0xbeefbeef);
-    fn pwrite_with<N: TryIntoCtx<Ctx, <Self as Index<RangeFrom<usize>>>::Output, Error = E>>(
+    fn pwrite_with<N: TryIntoCtx<Ctx, Self, Error = E>>(
         &mut self,
         n: N,
         offset: usize,
         ctx: Ctx,
-    ) -> result::Result<usize, E> {
-        let len = self.measure_with(&ctx);
-        if offset >= len {
-            return Err(error::Error::BadOffset(offset).into());
-        }
-        let dst = &mut self[offset..];
-        n.try_into_ctx(dst, ctx)
-    }
+    ) -> result::Result<usize, E>;
+
     /// Write `n` into `self` at `offset`, with a default `Ctx`. Updates the offset.
     #[inline]
-    fn gwrite<N: TryIntoCtx<Ctx, <Self as Index<RangeFrom<usize>>>::Output, Error = E>>(
+    fn gwrite<N: TryIntoCtx<Ctx, Self, Error = E>>(
         &mut self,
         n: N,
         offset: &mut usize,
@@ -72,29 +63,34 @@ where
         let ctx = Ctx::default();
         self.gwrite_with(n, offset, ctx)
     }
+
     /// Write `n` into `self` at `offset`, with the `ctx`. Updates the offset.
     #[inline]
-    fn gwrite_with<N: TryIntoCtx<Ctx, <Self as Index<RangeFrom<usize>>>::Output, Error = E>>(
+    fn gwrite_with<N: TryIntoCtx<Ctx, Self, Error = E>>(
         &mut self,
         n: N,
         offset: &mut usize,
         ctx: Ctx,
     ) -> result::Result<usize, E> {
         let o = *offset;
-        match self.pwrite_with(n, o, ctx) {
-            Ok(size) => {
-                *offset += size;
-                Ok(size)
-            }
-            err => err,
-        }
+        self.pwrite_with(n, o, ctx).map(|size| {
+            *offset += size;
+            size
+        })
     }
 }
 
-impl<
-        Ctx: Copy,
-        E: From<error::Error>,
-        R: ?Sized + Index<usize> + IndexMut<RangeFrom<usize>> + MeasureWith<Ctx>,
-    > Pwrite<Ctx, E> for R
-{
+impl<Ctx: Copy, E: From<error::Error>> Pwrite<Ctx, E> for [u8] {
+    fn pwrite_with<N: TryIntoCtx<Ctx, Self, Error = E>>(
+        &mut self,
+        n: N,
+        offset: usize,
+        ctx: Ctx,
+    ) -> result::Result<usize, E> {
+        if offset >= self.len() {
+            return Err(error::Error::BadOffset(offset).into());
+        }
+        let dst = &mut self[offset..];
+        n.try_into_ctx(dst, ctx)
+    }
 }


### PR DESCRIPTION
This PR adds a new type, `DynamicBuffer`, that automatically expands when `Pwrite`ing types into it. Details in the doc comments.

It also includes a relaxed definition of the `Pwrite` trait that, while technically an API break, is source-compatible and makes implementing custom containers easier.

Resolves #78. 