### PR TITLE
Do not error out of g{read,write}_with if the offset is equal to slice len

### DIFF
--- a/src/pread.rs
+++ b/src/pread.rs
@@ -167,7 +167,7 @@ impl<Ctx: Copy, E: From<error::Error>> Pread<Ctx, E> for [u8] {
         ctx: Ctx,
     ) -> result::Result<N, E> {
         let start = *offset;
-        if start >= self.len() {
+        if start > self.len() {
             return Err(error::Error::BadOffset(start).into());
         }
         N::try_from_ctx(&self[start..], ctx).map(|(n, size)| {

--- a/src/pwrite.rs
+++ b/src/pwrite.rs
@@ -87,7 +87,7 @@ impl<Ctx: Copy, E: From<error::Error>> Pwrite<Ctx, E> for [u8] {
         offset: usize,
         ctx: Ctx,
     ) -> result::Result<usize, E> {
-        if offset >= self.len() {
+        if offset > self.len() {
             return Err(error::Error::BadOffset(offset).into());
         }
         let dst = &mut self[offset..];


### PR DESCRIPTION
It does not allow reading zero-sized types (like possibly an empty array) from empty slice