### PR TITLE
Minor linting, warning fixes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,13 +12,13 @@ description = "A suite of powerful, extensible, generic, endian-aware Read/Write
 include = ["src/**/*", "Cargo.toml", "LICENSE", "README.md"]
 rust-version = "1.63"
 
-[dependencies]
-scroll_derive = { version = "0.11", optional = true, path = "scroll_derive" }
-
 [features]
 default = ["std"]
 std = []
-derive = ["scroll_derive"]
+derive = ["dep:scroll_derive"]
+
+[dependencies]
+scroll_derive = { version = "0.11", optional = true, path = "scroll_derive" }
 
 [dev-dependencies]
 rayon = "1"

--- a/examples/data_ctx.rs
+++ b/examples/data_ctx.rs
@@ -11,7 +11,7 @@ impl<'a> ctx::TryFromCtx<'a, Endian> for Data<'a> {
     fn try_from_ctx(src: &'a [u8], endian: Endian) -> Result<(Self, usize), Self::Error> {
         let name = src.pread::<&'a str>(0)?;
         let id = src.pread_with(name.len() + 1, endian)?;
-        Ok((Data { name: name, id: id }, name.len() + 4))
+        Ok((Data { name, id }, name.len() + 4))
     }
 }
 

--- a/src/endian.rs
+++ b/src/endian.rs
@@ -43,9 +43,6 @@ impl Endian {
     }
     #[inline]
     pub fn is_little(&self) -> bool {
-        match *self {
-            LE => true,
-            _ => false,
-        }
+        *self == LE
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,10 +1,7 @@
 use core::fmt::{self, Display};
 use core::result;
-
 #[cfg(feature = "std")]
-use std::error;
-#[cfg(feature = "std")]
-use std::io;
+use std::{error, io};
 
 #[derive(Debug)]
 /// A custom Scroll error
@@ -20,7 +17,8 @@ pub enum Error {
         size: usize,
         msg: &'static str,
     },
-    /// A custom Scroll error for reporting messages to clients
+    /// A custom Scroll error for reporting messages to clients.
+    /// For no-std, use [`Error::BadInput`] with a static string.
     #[cfg(feature = "std")]
     Custom(String),
     /// Returned when IO based errors are encountered
@@ -31,7 +29,7 @@ pub enum Error {
 #[cfg(feature = "std")]
 impl error::Error for Error {
     fn description(&self) -> &str {
-        match *self {
+        match self {
             Error::TooBig { .. } => "TooBig",
             Error::BadOffset(_) => "BadOffset",
             Error::BadInput { .. } => "BadInput",
@@ -40,7 +38,7 @@ impl error::Error for Error {
         }
     }
     fn cause(&self) -> Option<&dyn error::Error> {
-        match *self {
+        match self {
             Error::TooBig { .. } => None,
             Error::BadOffset(_) => None,
             Error::BadInput { .. } => None,
@@ -59,7 +57,7 @@ impl From<io::Error> for Error {
 
 impl Display for Error {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-        match *self {
+        match self {
             Error::TooBig { ref size, ref len } => {
                 write!(fmt, "type is too big ({}) for {}", size, len)
             }

--- a/src/leb128.rs
+++ b/src/leb128.rs
@@ -1,9 +1,8 @@
-use crate::ctx::TryFromCtx;
-use crate::error;
-use crate::Pread;
 use core::convert::{AsRef, From};
-use core::result;
-use core::u8;
+use core::{result, u8};
+
+use crate::ctx::TryFromCtx;
+use crate::{error, Pread};
 
 #[derive(Debug, PartialEq, Copy, Clone)]
 /// An unsigned leb128 integer

--- a/src/lesser.rs
+++ b/src/lesser.rs
@@ -1,5 +1,6 @@
-use crate::ctx::{FromCtx, IntoCtx, SizeWith};
 use std::io::{Read, Result, Write};
+
+use crate::ctx::{FromCtx, IntoCtx, SizeWith};
 
 /// An extension trait to `std::io::Read` streams; mainly targeted at reading primitive types with
 /// a known size.
@@ -104,8 +105,8 @@ pub trait IOread<Ctx: Copy>: Read {
     fn ioread_with<N: FromCtx<Ctx> + SizeWith<Ctx>>(&mut self, ctx: Ctx) -> Result<N> {
         let mut scratch = [0u8; 256];
         let size = N::size_with(&ctx);
-        let mut buf = &mut scratch[0..size];
-        self.read_exact(&mut buf)?;
+        let buf = &mut scratch[0..size];
+        self.read_exact(buf)?;
         Ok(N::from_ctx(buf, ctx))
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -253,8 +253,7 @@ pub use crate::pwrite::*;
 
 #[doc(hidden)]
 pub mod export {
-    pub use ::core::mem;
-    pub use ::core::result;
+    pub use ::core::{mem, result};
 }
 
 #[allow(unused)]
@@ -271,7 +270,9 @@ doc_comment!(include_str!("../README.md"));
 
 #[cfg(test)]
 mod tests {
-    #[allow(overflowing_literals)]
+    // FIXME: is this needed?  It used to be incorrectly declared.
+    #![allow(overflowing_literals)]
+
     use super::LE;
 
     #[test]
@@ -462,7 +463,7 @@ mod tests {
         fn try_into_ctx(self, this: &mut [u8], le: super::Endian) -> Result<usize, Self::Error> {
             use super::Pwrite;
             if this.len() < 2 {
-                return Err((ExternalError {}).into());
+                return Err(ExternalError {});
             }
             this.pwrite_with(self.0, 0, le)?;
             Ok(2)
@@ -474,7 +475,7 @@ mod tests {
         fn try_from_ctx(this: &'a [u8], le: super::Endian) -> Result<(Self, usize), Self::Error> {
             use super::Pread;
             if this.len() > 2 {
-                return Err((ExternalError {}).into());
+                return Err(ExternalError {});
             }
             let n = this.pread_with(0, le)?;
             Ok((Foo(n), 2))

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -270,9 +270,6 @@ doc_comment!(include_str!("../README.md"));
 
 #[cfg(test)]
 mod tests {
-    // FIXME: is this needed?  It used to be incorrectly declared.
-    #![allow(overflowing_literals)]
-
     use super::LE;
 
     #[test]


### PR DESCRIPTION
* Optimize/cleanup use statements
* Do not expose `scroll_derive` as a feature in Cargo.toml
* Minor clippy lints

- [x] There is a FIXME in the code that needs to be addressed before merging

The format args inlining was moved to #91 