### PR TITLE
Fix CI errors due to incorrect MSRV

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,9 +13,9 @@ jobs:
       matrix:
         build: [MSRV, stable, nightly, macos, win32, win64]
         include:
-          - build: MSRV # Minimum supported Rust version
+          - build: MSRV # Minimum supported Rust version, ensure it matches the rust-version in Cargo.toml
             os: ubuntu-latest
-            rust: 1.62.1
+            rust: 1.63
           - build: stable
             os: ubuntu-latest
             rust: stable

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ license = "MIT"
 documentation = "https://docs.rs/scroll"
 description = "A suite of powerful, extensible, generic, endian-aware Read/Write traits for byte buffers"
 include = ["src/**/*", "Cargo.toml", "LICENSE", "README.md"]
+rust-version = "1.63"
 
 [dependencies]
 scroll_derive = { version = "0.11", optional = true, path = "scroll_derive" }


### PR DESCRIPTION
 * Set minimum rust version to 1.63 due to rayon-core MSRV requirements, and add a matching `rust-version` in the Cargo.toml