### PR TITLE
Inline format args (better perf)

### DIFF
--- a/examples/data_ctx.rs
+++ b/examples/data_ctx.rs
@@ -20,5 +20,5 @@ fn main() {
     let data = bytes.pread_with::<Data>(0, BE).unwrap();
     assert_eq!(data.id, 0x01020304);
     assert_eq!(data.name.to_string(), "UserName".to_string());
-    println!("Data: {:?}", &data);
+    println!("Data: {data:?}");
 }

--- a/scroll_derive/README.md
+++ b/scroll_derive/README.md
@@ -21,7 +21,7 @@ use scroll::{Pread, Pwrite, Cread, LE};
 fn main (){
     let bytes = [0xefu8, 0xbe, 0xad, 0xde, 0, 0, 0, 0, 0, 0, 224, 63, 0xad, 0xde, 0xef, 0xbe];
     let data: Data = bytes.pread_with(0, LE).unwrap();
-    println!("data: {:?}", &data);
+    println!("data: {data:?}");
     assert_eq!(data.id, 0xdeadbeefu32);
     let mut bytes2 = vec![0; ::std::mem::size_of::<Data>()];
     bytes2.pwrite_with(data, 0, LE).unwrap();

--- a/scroll_derive/examples/main.rs
+++ b/scroll_derive/examples/main.rs
@@ -15,7 +15,7 @@ fn main() {
         0xefu8, 0xbe, 0xad, 0xde, 0, 0, 0, 0, 0, 0, 224, 63, 0xad, 0xde, 0xef, 0xbe,
     ];
     let data: Data = bytes.pread_with(0, LE).unwrap();
-    println!("data: {:?}", &data);
+    println!("data: {data:?}");
     assert_eq!(data.id, 0xdeadbeefu32);
     let mut bytes2 = vec![0; ::std::mem::size_of::<Data>()];
     bytes2.pwrite_with(data, 0, LE).unwrap();

--- a/scroll_derive/tests/tests.rs
+++ b/scroll_derive/tests/tests.rs
@@ -30,7 +30,7 @@ struct Data {
 fn test_data() {
     let bytes = [0xefu8, 0xbe, 0xad, 0xde, 0, 0, 0, 0, 0, 0, 224, 63];
     let data: Data = bytes.pread_with(0, LE).unwrap();
-    println!("data: {:?}", &data);
+    println!("data: {data:?}");
     assert_eq!(data.id, 0xdeadbeefu32);
     assert_eq!(data.timestamp, 0.5f64);
     let mut bytes2 = vec![0; ::std::mem::size_of::<Data>()];
@@ -49,7 +49,7 @@ struct Data2 {
 fn test_array() {
     let bytes = [0u8; 64];
     let data: Data2 = bytes.pread_with(0, LE).unwrap();
-    println!("data: {:?}", &data);
+    println!("data: {data:?}");
 }
 
 #[derive(Debug, PartialEq, Pread, Pwrite, SizeWith)]
@@ -61,7 +61,7 @@ struct Data3 {
 fn test_sizewith() {
     let bytes = [0u8; 64];
     let data: Data3 = bytes.gread_with(&mut 0, LE).unwrap();
-    println!("data: {:?}", &data);
+    println!("data: {data:?}");
 }
 
 #[derive(Debug, PartialEq, IOread, IOwrite, SizeWith)]
@@ -75,7 +75,7 @@ struct Data4 {
 fn test_ioread() {
     let bytes = [0, 1, 2, 3, 0xde, 0xed, 0xbe, 0xaf];
     let data: Data4 = bytes.cread_with(0, LE);
-    println!("data: {:?}", &data);
+    println!("data: {data:?}");
     assert_eq!(data.name, 50462976);
     assert_eq!(data.j, 0xedde);
     assert_eq!(data.arr, [0xbe, 0xaf]);
@@ -85,21 +85,21 @@ fn test_ioread() {
 fn test_iowrite() {
     let bytes = [0, 1, 2, 3, 0xde, 0xed, 0xbe, 0xaf];
     let data: Data4 = bytes.cread_with(0, LE);
-    println!("data: {:?}", &data);
+    println!("data: {data:?}");
     assert_eq!(data.name, 50462976);
     assert_eq!(data.j, 0xedde);
     assert_eq!(data.arr, [0xbe, 0xaf]);
 
     let mut bytes_null = [0u8; 8];
     bytes_null.cwrite_with(&data, 0, LE);
-    println!("bytes_null: {:?}", &bytes_null);
-    println!("bytes     : {:?}", &bytes);
+    println!("bytes_null: {bytes_null:?}");
+    println!("bytes     : {bytes:?}");
     assert_eq!(bytes_null, bytes);
 
     let mut bytes_null = [0u8; 8];
     bytes_null.cwrite_with(data, 0, LE);
-    println!("bytes_null: {:?}", &bytes_null);
-    println!("bytes     : {:?}", &bytes);
+    println!("bytes_null: {bytes_null:?}");
+    println!("bytes     : {bytes:?}");
     assert_eq!(bytes_null, bytes);
 }
 
@@ -116,13 +116,13 @@ struct Data5 {
 fn test_pread_arrays() {
     let bytes = [0, 1, 2, 3, 0, 0, 0xde, 0xed, 0xad, 0xde, 0xef, 0xbe];
     let data: Data5 = bytes.pread_with(0, LE).unwrap();
-    println!("data: {:?}", &data);
+    println!("data: {data:?}");
     assert_eq!(data.name, 50462976);
     assert_eq!(data.arr1, [0xde, 0xed]);
     assert_eq!(data.arr2, [0xdead, 0xbeef]);
     let offset = &mut 0;
     let data: Data5 = bytes.gread_with(offset, LE).unwrap();
-    println!("data: {:?}", &data);
+    println!("data: {data:?}");
     assert_eq!(data.name, 50462976);
     assert_eq!(data.arr1, [0xde, 0xed]);
     assert_eq!(data.arr2, [0xdead, 0xbeef]);
@@ -141,8 +141,8 @@ fn test_array_copy() {
     let bytes = [0xde, 0xed, 0xef, 0xbe, 0x68, 0x65, 0x6c, 0x6c, 0x0];
     let data: Data6 = bytes.pread_with(0, LE).unwrap();
     let name: &str = data.name.pread(0).unwrap();
-    println!("data: {:?}", &data);
-    println!("data.name: {:?}", name);
+    println!("data: {data:?}");
+    println!("data.name: {name:?}");
     assert_eq!(data.id, 0xbeefedde);
     assert_eq!(name, "hell");
 }

--- a/src/ctx.rs
+++ b/src/ctx.rs
@@ -729,7 +729,7 @@ impl<'a> TryIntoCtx for &'a [u8] {
         let src_len = self.len() as isize;
         let dst_len = dst.len() as isize;
         // if src_len < 0 || dst_len < 0 || offset < 0 {
-        //     return Err(error::Error::BadOffset(format!("requested operation has negative casts: src len: {} dst len: {} offset: {}", src_len, dst_len, offset)).into())
+        //     return Err(error::Error::BadOffset(format!("requested operation has negative casts: src len: {src_len} dst len: {dst_len} offset: {offset}")).into())
         // }
         if src_len > dst_len {
             Err(error::Error::TooBig {

--- a/src/error.rs
+++ b/src/error.rs
@@ -61,21 +61,21 @@ impl Display for Error {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         match *self {
             Error::TooBig { ref size, ref len } => {
-                write!(fmt, "type is too big ({}) for {}", size, len)
+                write!(fmt, "type is too big ({size}) for {len}")
             }
             Error::BadOffset(ref offset) => {
-                write!(fmt, "bad offset {}", offset)
+                write!(fmt, "bad offset {offset}")
             }
             Error::BadInput { ref msg, ref size } => {
-                write!(fmt, "bad input {} ({})", msg, size)
+                write!(fmt, "bad input {msg} ({size})")
             }
             #[cfg(feature = "std")]
             Error::Custom(ref msg) => {
-                write!(fmt, "{}", msg)
+                write!(fmt, "{msg}")
             }
             #[cfg(feature = "std")]
             Error::IO(ref err) => {
-                write!(fmt, "{}", err)
+                write!(fmt, "{err}")
             }
         }
     }

--- a/src/leb128.rs
+++ b/src/leb128.rs
@@ -185,7 +185,7 @@ mod tests {
         let bytes = &buf[..];
         let num = bytes.pread::<Uleb128>(0).unwrap();
         #[cfg(feature = "std")]
-        println!("num: {:?}", &num);
+        println!("num: {num:?}");
         assert_eq!(130u64, num.into());
         assert_eq!(num.size(), 2);
 
@@ -193,7 +193,7 @@ mod tests {
         let bytes = &buf[..];
         let num = bytes.pread::<Uleb128>(0).unwrap();
         #[cfg(feature = "std")]
-        println!("num: {:?}", &num);
+        println!("num: {num:?}");
         assert_eq!(0u64, num.into());
         assert_eq!(num.size(), 1);
 
@@ -201,7 +201,7 @@ mod tests {
         let bytes = &buf[..];
         let num = bytes.pread::<Uleb128>(0).unwrap();
         #[cfg(feature = "std")]
-        println!("num: {:?}", &num);
+        println!("num: {num:?}");
         assert_eq!(0x21u64, num.into());
         assert_eq!(num.size(), 1);
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -360,22 +360,22 @@ mod tests {
         let b = &bytes[..];
         let s: &str = b.pread(0).unwrap();
         #[cfg(feature = "std")]
-        println!("str: {}", s);
+        println!("str: {s}");
         assert_eq!(s.len(), bytes[..].len() - 1);
         let bytes: &[u8] = b"hello, world!\0some_other_things";
         let hello_world: &str = bytes.pread_with(0, StrCtx::Delimiter(NULL)).unwrap();
         #[cfg(feature = "std")]
-        println!("{:?}", &hello_world);
+        println!("{hello_world:?}");
         assert_eq!(hello_world.len(), 13);
         let hello: &str = bytes.pread_with(0, StrCtx::Delimiter(SPACE)).unwrap();
         #[cfg(feature = "std")]
-        println!("{:?}", &hello);
+        println!("{hello:?}");
         assert_eq!(hello.len(), 6);
         // this could result in underflow so we just try it
         let _error = bytes.pread_with::<&str>(6, StrCtx::Delimiter(SPACE));
         let error = bytes.pread_with::<&str>(7, StrCtx::Delimiter(SPACE));
         #[cfg(feature = "std")]
-        println!("{:?}", &error);
+        println!("{error:?}");
         assert!(error.is_ok());
     }
 
@@ -386,16 +386,16 @@ mod tests {
         let bytes: &[u8] = b"";
         let hello_world = bytes.pread_with::<&str>(0, StrCtx::Delimiter(NULL));
         #[cfg(feature = "std")]
-        println!("1 {:?}", &hello_world);
-        assert_eq!(hello_world.is_err(), true);
+        println!("1 {hello_world:?}");
+        assert!(hello_world.is_err());
         let error = bytes.pread_with::<&str>(7, StrCtx::Delimiter(SPACE));
         #[cfg(feature = "std")]
-        println!("2 {:?}", &error);
+        println!("2 {error:?}");
         assert!(error.is_err());
         let bytes: &[u8] = b"\0";
         let null = bytes.pread::<&str>(0).unwrap();
         #[cfg(feature = "std")]
-        println!("3 {:?}", &null);
+        println!("3 {null:?}");
         assert_eq!(null.len(), 0);
     }
 

--- a/tests/api.rs
+++ b/tests/api.rs
@@ -146,12 +146,12 @@ fn lifetime_passthrough_<'a>(segments: &Segments<'a>, section_name: &str) -> Opt
     let segment_name = "__TEXT";
     for segment in &segments.segments {
         if let Ok(name) = segment.name() {
-            println!("segment.name: {}", name);
+            println!("segment.name: {name}");
             if name == segment_name {
                 if let Ok(sections) = segment.sections() {
                     for section in sections {
                         let sname = section.name().unwrap();
-                        println!("section.name: {}", sname);
+                        println!("section.name: {sname}");
                         if section_name == sname {
                             return Some(section.data);
                         }


### PR DESCRIPTION
This is a subset of the original #84 

Make code a bit easier to read, and also, per rust issue 112156, there is a 6% perf hit when using refs with format, so this PR also fixes that.

See https://github.com/rust-lang/rust/issues/112156