### PR TITLE
pwrite: allow writes to empty slice

### DIFF
--- a/src/pwrite.rs
+++ b/src/pwrite.rs
@@ -87,7 +87,7 @@ impl<Ctx: Copy, E: From<error::Error>> Pwrite<Ctx, E> for [u8] {
         offset: usize,
         ctx: Ctx,
     ) -> result::Result<usize, E> {
-        if offset >= self.len() {
+        if offset > self.len() {
             return Err(error::Error::BadOffset(offset).into());
         }
         let dst = &mut self[offset..];


### PR DESCRIPTION
`slice[len..]` is a valid subslice, this is going to generate an empty subslice, but this won't be considered out of range.

https://play.rust-lang.org/?version=stable&mode=release&edition=2021&gist=31f38d269157a3f6c6ac7019d912456f

cc @RaitoBezarius 