### PR TITLE
Fixed incorrect behaviour on str impl.

### DIFF
--- a/src/ctx.rs
+++ b/src/ctx.rs
@@ -845,6 +845,11 @@ impl<Ctx: Copy, T: TryIntoCtx<Ctx, Error = error::Error>, const N: usize> TryInt
         Ok(offset)
     }
 }
+impl<Ctx, T: SizeWith<Ctx>, const N: usize> SizeWith<Ctx> for [T; N] {
+    fn size_with(ctx: &Ctx) -> usize {
+        T::size_with(ctx) * N
+    }
+}
 
 #[cfg(feature = "std")]
 impl<'a> TryFromCtx<'a> for &'a CStr {

--- a/src/ctx.rs
+++ b/src/ctx.rs
@@ -765,6 +765,12 @@ macro_rules! sizeof_impl {
                 size_of::<$ty>()
             }
         }
+        impl SizeWith for $ty {
+            #[inline]
+            fn size_with(_ctx: &()) -> usize {
+                size_of::<$ty>()
+            }
+        }
     };
 }
 

--- a/src/ctx.rs
+++ b/src/ctx.rs
@@ -666,10 +666,17 @@ impl<'a> TryFromCtx<'a, StrCtx> for &'a str {
     fn try_from_ctx(src: &'a [u8], ctx: StrCtx) -> Result<(Self, usize), Self::Error> {
         let len = match ctx {
             StrCtx::Length(len) => len,
-            StrCtx::Delimiter(delimiter) => match src.iter().copied().position(|c| c == delimiter) {
-                Some(str_len) => str_len,
-                None => return Err(error::Error::BadInput { size: 0, msg: "No delimiter was found." })
-            },
+            StrCtx::Delimiter(delimiter) => {
+                match src.iter().copied().position(|c| c == delimiter) {
+                    Some(str_len) => str_len,
+                    None => {
+                        return Err(error::Error::BadInput {
+                            size: 0,
+                            msg: "No delimiter was found.",
+                        })
+                    }
+                }
+            }
             StrCtx::DelimiterUntil(delimiter, len) => {
                 if len > src.len() {
                     return Err(error::Error::TooBig {
@@ -679,7 +686,12 @@ impl<'a> TryFromCtx<'a, StrCtx> for &'a str {
                 };
                 match src.iter().copied().position(|c| c == delimiter) {
                     Some(str_len) => str_len.min(len),
-                    None => return Err(error::Error::BadInput { size: 0, msg: "No delimiter was found." })
+                    None => {
+                        return Err(error::Error::BadInput {
+                            size: 0,
+                            msg: "No delimiter was found.",
+                        })
+                    }
                 }
             }
         };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -421,8 +421,7 @@ mod tests {
             .pread_with::<&str>(0, StrCtx::Delimiter(NULL))
             .unwrap();
         assert_eq!(more, "more");
-        let result = bytes
-            .pread_with::<&str>(more.len() + 1, StrCtx::Delimiter(NULL));
+        let result = bytes.pread_with::<&str>(more.len() + 1, StrCtx::Delimiter(NULL));
         assert!(result.is_err());
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -374,7 +374,7 @@ mod tests {
         let error = bytes.pread_with::<&str>(7, StrCtx::Delimiter(SPACE));
         #[cfg(feature = "std")]
         println!("{error:?}");
-        assert!(error.is_ok());
+        assert!(error.is_err());
     }
 
     /// In this test, we are testing preading
@@ -390,7 +390,7 @@ mod tests {
         let hello_world = bytes.pread_with::<&str>(0, StrCtx::Delimiter(NULL));
         #[cfg(feature = "std")]
         println!("1 {hello_world:?}");
-        assert!(hello_world.unwrap().is_empty());
+        assert!(hello_world.is_err());
         let error = bytes.pread_with::<&str>(7, StrCtx::Delimiter(SPACE));
         #[cfg(feature = "std")]
         println!("2 {error:?}");
@@ -421,10 +421,9 @@ mod tests {
             .pread_with::<&str>(0, StrCtx::Delimiter(NULL))
             .unwrap();
         assert_eq!(more, "more");
-        let bytes = bytes
-            .pread_with::<&str>(more.len() + 1, StrCtx::Delimiter(NULL))
-            .unwrap();
-        assert_eq!(bytes, "bytes");
+        let result = bytes
+            .pread_with::<&str>(more.len() + 1, StrCtx::Delimiter(NULL));
+        assert!(result.is_err());
     }
 
     use core::fmt::{self, Display};

--- a/tests/api.rs
+++ b/tests/api.rs
@@ -3,7 +3,7 @@
 use std::ops::{Deref, DerefMut};
 
 use scroll::ctx::SizeWith as _;
-use scroll::{ctx, Cread, Pread, Result};
+use scroll::{ctx, Cread, Endian, Pread, Result};
 
 #[derive(Default)]
 pub struct Section<'a> {
@@ -375,4 +375,9 @@ fn test_fixed_array_rw() {
     let mut buf = [0x00u8; 4];
     buf.pwrite([0x1337u16, 0x1337], 0).unwrap();
     assert_eq!(buf, bytes);
+}
+
+#[test]
+fn test_fixed_array_size_with() {
+    assert_eq!(<[u32; 3]>::size_with(&Endian::Little), 12);
 }


### PR DESCRIPTION
The default `TryFromCtx` impl for `&str` succeeds, even if a null byte is missing. This caused the unexpected behavior in #95. I'm unsure, if this is intended behavior, but while developing the previously referenced PR it was certainly unexpected.