### PR TITLE
Added SizeWith impl for numeric types without Ctx.

### DIFF
--- a/src/ctx.rs
+++ b/src/ctx.rs
@@ -750,6 +750,12 @@ macro_rules! sizeof_impl {
                 size_of::<$ty>()
             }
         }
+        impl SizeWith for $ty {
+            #[inline]
+            fn size_with(_ctx: &()) -> usize {
+                size_of::<$ty>()
+            }
+        }
     };
 }
 


### PR DESCRIPTION
This PR introduces `SizeWith` impls for numeric types, without requiring `Endian` as context. It wasn't immediately clear, to me, why the ctx was required.