### PR TITLE
Added SizeWith impl for fixed array.

### DIFF
--- a/src/ctx.rs
+++ b/src/ctx.rs
@@ -830,6 +830,11 @@ impl<Ctx: Copy, T: TryIntoCtx<Ctx, Error = error::Error>, const N: usize> TryInt
         Ok(offset)
     }
 }
+impl<Ctx: Copy, T: SizeWith<Ctx>, const N: usize> SizeWith<Ctx> for [T; N] {
+    fn size_with(ctx: &Ctx) -> usize {
+        T::size_with(ctx) * N
+    }
+}
 
 #[cfg(feature = "std")]
 impl<'a> TryFromCtx<'a> for &'a CStr {

--- a/src/ctx.rs
+++ b/src/ctx.rs
@@ -830,7 +830,7 @@ impl<Ctx: Copy, T: TryIntoCtx<Ctx, Error = error::Error>, const N: usize> TryInt
         Ok(offset)
     }
 }
-impl<Ctx: Copy, T: SizeWith<Ctx>, const N: usize> SizeWith<Ctx> for [T; N] {
+impl<Ctx, T: SizeWith<Ctx>, const N: usize> SizeWith<Ctx> for [T; N] {
     fn size_with(ctx: &Ctx) -> usize {
         T::size_with(ctx) * N
     }

--- a/tests/api.rs
+++ b/tests/api.rs
@@ -3,7 +3,7 @@
 use std::ops::{Deref, DerefMut};
 
 use scroll::ctx::SizeWith as _;
-use scroll::{ctx, Cread, Pread, Result};
+use scroll::{ctx, Cread, Endian, Pread, Result};
 
 #[derive(Default)]
 pub struct Section<'a> {
@@ -375,4 +375,9 @@ fn test_fixed_array_rw() {
     let mut buf = [0x00u8; 4];
     buf.pwrite([0x1337u16, 0x1337], 0).unwrap();
     assert_eq!(buf, bytes);
+}
+
+#[test]
+fn test_fixed_array_size_with() {
+    assert_eq!(<[u32; 3]>::size_with(&Endian::Little), 12);
 }


### PR DESCRIPTION
This PR adds a generic implementation of `SizeWith` for a fixed size array.