### PR TITLE
Custom ctx override for derive macro

### DIFF
--- a/scroll_derive/examples/derive_custom_ctx.rs
+++ b/scroll_derive/examples/derive_custom_ctx.rs
@@ -1,0 +1,72 @@
+use scroll_derive::{Pread, Pwrite, SizeWith};
+
+#[derive(Debug, PartialEq)]
+struct CustomCtx {
+    buf: Vec<u8>,
+}
+impl CustomCtx {
+    fn len() -> usize {
+        3 + 2
+    }
+}
+impl<'a> TryFromCtx<'a, usize> for CustomCtx {
+    type Error = scroll::Error;
+
+    fn try_from_ctx(from: &'a [u8], ctx: usize) -> Result<(Self, usize), Self::Error> {
+        let offset = &mut 0;
+        let buf = from.gread_with::<&[u8]>(offset, ctx)?.to_owned();
+        Ok((Self { buf }, *offset))
+    }
+}
+impl<'a> TryIntoCtx<usize> for &'a CustomCtx {
+    type Error = scroll::Error;
+    fn try_into_ctx(self, dst: &mut [u8], ctx: usize) -> Result<usize, Self::Error> {
+        let offset = &mut 0;
+        for i in 0..(ctx.min(self.buf.len())) {
+            dst.gwrite(self.buf[i], offset)?;
+        }
+        Ok(*offset)
+    }
+}
+impl SizeWith<usize> for CustomCtx {
+    fn size_with(ctx: &usize) -> usize {
+        *ctx
+    }
+}
+
+#[derive(Debug, PartialEq, Pread, Pwrite, SizeWith)]
+#[repr(C)]
+struct Data {
+    id: u32,
+    timestamp: f64,
+    #[scroll(ctx = BE)]
+    arr: [u16; 2],
+    #[scroll(ctx = CustomCtx::len())]
+    custom_ctx: CustomCtx,
+}
+
+use scroll::{
+    ctx::{SizeWith, TryFromCtx, TryIntoCtx},
+    Pread, Pwrite, BE, LE,
+};
+
+fn main() {
+    let bytes = [
+        0xefu8, 0xbe, 0xad, 0xde, 0, 0, 0, 0, 0, 0, 224, 63, 0xad, 0xde, 0xef, 0xbe, 0xaa, 0xbb,
+        0xcc, 0xdd, 0xee,
+    ];
+    let data: Data = bytes.pread_with(0, LE).unwrap();
+    println!("data: {data:?}");
+    assert_eq!(data.id, 0xdeadbeefu32);
+    assert_eq!(data.arr, [0xadde, 0xefbe]);
+    let mut bytes2 = vec![0; ::std::mem::size_of::<Data>()];
+    bytes2.pwrite_with(data, 0, LE).unwrap();
+    let data: Data = bytes.pread_with(0, LE).unwrap();
+    let data2: Data = bytes2.pread_with(0, LE).unwrap();
+    assert_eq!(data, data2);
+
+    /*
+    let data: Data = bytes.cread_with(0, LE);
+       assert_eq!(data, data2);
+    */
+}

--- a/scroll_derive/examples/derive_custom_ctx.rs
+++ b/scroll_derive/examples/derive_custom_ctx.rs
@@ -76,6 +76,6 @@ fn main() {
     let data: Data = bytes.pread_with(0, LE).unwrap();
     let data2: Data = bytes2.pread_with(0, LE).unwrap();
     assert_eq!(data, data2);
-    // Not enough bytes because of ctx dependant length being too long.
+    // Not enough bytes because of ctx dependent length being too long.
     assert!(bytes.pread_with::<Data>(0, BE).is_err())
 }

--- a/scroll_derive/src/lib.rs
+++ b/scroll_derive/src/lib.rs
@@ -63,7 +63,7 @@ fn custom_ctx(field: &syn::Field) -> Option<proc_macro2::TokenStream> {
             if meta.path.is_ident("ctx") {
                 // parsed #[scroll(ctx..)]
                 let value = meta.value()?; // parsed #[scroll(ctx = ..)]
-                expr = Some(value.parse::<syn::Expr>()?); // parsed #[scroll(ctx = expr)]
+                expr = Some(value.parse::<syn::Expr>()?.into_token_stream()); // parsed #[scroll(ctx = expr)]
                 return Ok(());
             }
             Err(meta.error(match meta.path.get_ident() {
@@ -72,7 +72,7 @@ fn custom_ctx(field: &syn::Field) -> Option<proc_macro2::TokenStream> {
             }))
         });
         match res {
-            Ok(_) => expr.map(|x| x.into_token_stream()),
+            Ok(()) => expr,
             Err(e) => Some(e.into_compile_error()),
         }
     })

--- a/scroll_derive/src/lib.rs
+++ b/scroll_derive/src/lib.rs
@@ -323,6 +323,10 @@ fn size_with(
         .iter()
         .map(|f| {
             let ty = &f.ty;
+            let custom_ctx = custom_ctx(f).map(|x| quote! {&#x});
+            let default_ctx =
+                syn::Ident::new("ctx", proc_macro2::Span::call_site()).into_token_stream();
+            let ctx = custom_ctx.unwrap_or(default_ctx);
             match *ty {
                 syn::Type::Array(ref array) => {
                     let elem = &array.elem;
@@ -333,7 +337,7 @@ fn size_with(
                         }) => {
                             let size = int.base10_parse::<usize>().unwrap();
                             quote! {
-                                (#size * <#elem>::size_with(ctx))
+                                (#size * <#elem>::size_with(#ctx))
                             }
                         }
                         _ => panic!("Pread derive with bad array constexpr"),
@@ -341,7 +345,7 @@ fn size_with(
                 }
                 _ => {
                     quote! {
-                        <#ty>::size_with(ctx)
+                        <#ty>::size_with(#ctx)
                     }
                 }
             }

--- a/scroll_derive/src/lib.rs
+++ b/scroll_derive/src/lib.rs
@@ -66,10 +66,10 @@ fn custom_ctx(field: &syn::Field) -> Option<proc_macro2::TokenStream> {
                 expr = Some(value.parse::<syn::Expr>()?); // parsed #[scroll(ctx = expr)]
                 return Ok(());
             }
-            Err(meta.error(format!(
-                "unrecognized attribute: {}",
-                meta.path.get_ident().unwrap()
-            )))
+            Err(meta.error(match meta.path.get_ident() {
+                Some(ident) => format!("unrecognized attribute: {ident}"),
+                None => "unrecognized and invalid attribute".to_owned(),
+            }))
         });
         match res {
             Ok(_) => expr.map(|x| x.into_token_stream()),


### PR DESCRIPTION
Add attribute to override the context in `scroll-derive` used like the following:
```rust
#[derive(Pread, Pwrite, SizeWith)]
#[repr(C)]
struct Data {
    id: u32,
    timestamp: f64,
    #[scroll(ctx = BE)]
    arr: [u16; 2],
    #[scroll(ctx = CustomCtx::len())]
    custom_ctx: CustomCtx,
}
```
where `ctx` doesn't have to be of type `Endian` and ignores `pread_with`'s (and related) `ctx` argument.

Use case for this includes using the derive macro for structs that don't use `Endian` as their context and deriving many `Network` Endian structs while still being able to use `pread`/`gread`/`pwrite`/`gwrite` without having to specify `Network` Endian every time.

A future extension to this can enable using previous fields in the expression which would enable a pattern like:
```rust
#[derive(Pread, Pwrite, SizeWith)]
#[repr(C)]
struct Data<'b> {
    header: u32,
    #[scroll(ctx = header as usize)]
    body: &'b [u8],
}
```

without having to manually implement the various traits.

Let me know if you're interested in this idea and/or the future extension. Thanks!