### PR TITLE
Remove unneeded unit expression

### DIFF
--- a/scroll_derive/src/lib.rs
+++ b/scroll_derive/src/lib.rs
@@ -574,7 +574,6 @@ fn impl_into_ctx(
                 use ::scroll::Cwrite;
                 let offset = &mut 0;
                 #(#items;)*;
-                ()
             }
         }
 


### PR DESCRIPTION
This causes downstream clippy warnings on #[derive(IOwrite)]:

  warning: unneeded unit expression
     --> src/types.rs:195:59
      |
  195 | #[derive(Debug, Copy, Clone, DerivePread, Pwrite, IOread, IOwrite, SizeWith)]
      |                                                           ^^^^^^^
      |
      = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#unused_unit
      = note: this warning originates in the derive macro `IOwrite` (in Nightly builds, run with -Z macro-backtrace for more info)
