### PR TITLE
Implement core::error::Error

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,7 @@ jobs:
         include:
           - build: MSRV # Minimum supported Rust version, ensure it matches the rust-version in Cargo.toml
             os: ubuntu-latest
-            rust: 1.63
+            rust: 1.81
           - build: stable
             os: ubuntu-latest
             rust: stable

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ license = "MIT"
 documentation = "https://docs.rs/scroll"
 description = "A suite of powerful, extensible, generic, endian-aware Read/Write traits for byte buffers"
 include = ["src/**/*", "Cargo.toml", "LICENSE", "README.md"]
-rust-version = "1.63"
+rust-version = "1.81"
 
 [features]
 default = ["std"]

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,7 +1,7 @@
 use core::fmt::{self, Display};
-use core::result;
+use core::{error, result};
 #[cfg(feature = "std")]
-use std::{error, io};
+use std::io;
 
 #[derive(Debug)]
 /// A custom Scroll error
@@ -26,14 +26,15 @@ pub enum Error {
     IO(io::Error),
 }
 
-#[cfg(feature = "std")]
 impl error::Error for Error {
     fn description(&self) -> &str {
         match self {
             Error::TooBig { .. } => "TooBig",
             Error::BadOffset(_) => "BadOffset",
             Error::BadInput { .. } => "BadInput",
+            #[cfg(feature = "std")]
             Error::Custom(_) => "Custom",
+            #[cfg(feature = "std")]
             Error::IO(_) => "IO",
         }
     }
@@ -42,7 +43,9 @@ impl error::Error for Error {
             Error::TooBig { .. } => None,
             Error::BadOffset(_) => None,
             Error::BadInput { .. } => None,
+            #[cfg(feature = "std")]
             Error::Custom(_) => None,
+            #[cfg(feature = "std")]
             Error::IO(ref io) => io.source(),
         }
     }


### PR DESCRIPTION
Now that `core::error::Error` is available in stable Rust (as of 1.81.0), we can close #111.