### PR TITLE
Use Rust 2024, bump MSRV to 1.85

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,7 @@ jobs:
         include:
           - build: MSRV # Minimum supported Rust version, ensure it matches the rust-version in Cargo.toml
             os: ubuntu-latest
-            rust: 1.81
+            rust: 1.85
           - build: stable
             os: ubuntu-latest
             rust: stable

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,14 +3,14 @@ name = "scroll"
 version = "0.12.0"
 authors = ["m4b <m4b.github.io@gmail.com>", "Ted Mielczarek <ted@mielczarek.org>"]
 readme = "README.md"
-edition = "2021"
+edition = "2024"
 keywords = ["bytes", "endian", "immutable", "pread", "pwrite"]
 repository = "https://github.com/m4b/scroll"
 license = "MIT"
 documentation = "https://docs.rs/scroll"
 description = "A suite of powerful, extensible, generic, endian-aware Read/Write traits for byte buffers"
 include = ["src/**/*", "Cargo.toml", "LICENSE", "README.md"]
-rust-version = "1.81"
+rust-version = "1.85"
 
 [features]
 default = ["std"]

--- a/examples/data_ctx.rs
+++ b/examples/data_ctx.rs
@@ -1,4 +1,4 @@
-use scroll::{ctx, Endian, Pread, BE};
+use scroll::{BE, Endian, Pread, ctx};
 
 #[derive(Debug)]
 struct Data<'a> {

--- a/src/ctx.rs
+++ b/src/ctx.rs
@@ -180,14 +180,14 @@
 //! }
 //! ```
 
-use core::mem::{size_of, MaybeUninit};
+use core::mem::{MaybeUninit, size_of};
 use core::ptr::copy_nonoverlapping;
 use core::{result, str};
 #[cfg(feature = "std")]
 use std::ffi::{CStr, CString};
 
 use crate::endian::Endian;
-use crate::{error, Pread, Pwrite};
+use crate::{Pread, Pwrite, error};
 
 /// A trait for measuring how large something is; for a byte sequence, it will be its length.
 pub trait MeasureWith<Ctx> {
@@ -853,7 +853,7 @@ impl<'a> TryFromCtx<'a> for &'a CStr {
                 return Err(error::Error::BadInput {
                     size: 0,
                     msg: "The input doesn't contain a null byte",
-                })
+                });
             }
         };
 

--- a/src/endian.rs
+++ b/src/endian.rs
@@ -28,11 +28,7 @@ impl Default for Endian {
 impl From<bool> for Endian {
     #[inline]
     fn from(little_endian: bool) -> Self {
-        if little_endian {
-            LE
-        } else {
-            BE
-        }
+        if little_endian { LE } else { BE }
     }
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -46,7 +46,7 @@ impl error::Error for Error {
             #[cfg(feature = "std")]
             Error::Custom(_) => None,
             #[cfg(feature = "std")]
-            Error::IO(ref io) => io.source(),
+            Error::IO(io) => io.source(),
         }
     }
 }
@@ -61,21 +61,21 @@ impl From<io::Error> for Error {
 impl Display for Error {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         match self {
-            Error::TooBig { ref size, ref len } => {
+            Error::TooBig { size, len } => {
                 write!(fmt, "type is too big ({size}) for {len}")
             }
-            Error::BadOffset(ref offset) => {
+            Error::BadOffset(offset) => {
                 write!(fmt, "bad offset {offset}")
             }
-            Error::BadInput { ref msg, ref size } => {
+            Error::BadInput { msg, size } => {
                 write!(fmt, "bad input {msg} ({size})")
             }
             #[cfg(feature = "std")]
-            Error::Custom(ref msg) => {
+            Error::Custom(msg) => {
                 write!(fmt, "{msg}")
             }
             #[cfg(feature = "std")]
-            Error::IO(ref err) => {
+            Error::IO(err) => {
                 write!(fmt, "{err}")
             }
         }

--- a/src/leb128.rs
+++ b/src/leb128.rs
@@ -2,7 +2,7 @@ use core::convert::{AsRef, From};
 use core::result;
 
 use crate::ctx::TryFromCtx;
-use crate::{error, Pread};
+use crate::{Pread, error};
 
 #[derive(Debug, PartialEq, Copy, Clone)]
 /// An unsigned leb128 integer

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -293,7 +293,7 @@ mod tests {
         ($write:ident, $read:ident, $deadbeef:expr) => {
             #[test]
             fn $write() {
-                use super::{Pread, Pwrite, BE};
+                use super::{BE, Pread, Pwrite};
                 let mut bytes: [u8; 8] = [0, 0, 0, 0, 0, 0, 0, 0];
                 let b = &mut bytes[..];
                 b.pwrite_with::<$read>($deadbeef, 0, LE).unwrap();
@@ -337,8 +337,8 @@ mod tests {
 
     #[test]
     fn pread_slice() {
-        use super::ctx::StrCtx;
         use super::Pread;
+        use super::ctx::StrCtx;
         let bytes: [u8; 2] = [0x7e, 0xef];
         let b = &bytes[..];
         let iserr: Result<&str, _> = b.pread_with(0, StrCtx::Length(3));
@@ -352,8 +352,8 @@ mod tests {
 
     #[test]
     fn pread_str() {
-        use super::ctx::*;
         use super::Pread;
+        use super::ctx::*;
         let bytes: [u8; 2] = [0x2e, 0x0];
         let b = &bytes[..];
         let s: &str = b.pread(0).unwrap();
@@ -384,8 +384,8 @@ mod tests {
     /// the fact that if you do &x[x.len()..] you get an empty slice.
     #[test]
     fn pread_str_weird() {
-        use super::ctx::*;
         use super::Pread;
+        use super::ctx::*;
         let bytes: &[u8] = b"";
         let hello_world = bytes.pread_with::<&str>(0, StrCtx::Delimiter(NULL));
         #[cfg(feature = "std")]
@@ -544,7 +544,7 @@ mod tests {
         ($read:ident, $val:expr, $typ:ty) => {
             #[test]
             fn $read() {
-                use super::{Pread, Pwrite, BE, LE};
+                use super::{BE, LE, Pread, Pwrite};
                 let mut buffer = [0u8; 16];
                 let offset = &mut 0;
                 buffer.gwrite_with($val.clone(), offset, LE).unwrap();
@@ -618,8 +618,8 @@ mod tests {
 
     #[test]
     fn gread_slice() {
-        use super::ctx::StrCtx;
         use super::Pread;
+        use super::ctx::StrCtx;
         let bytes: [u8; 2] = [0x7e, 0xef];
         let b = &bytes[..];
         let offset = &mut 0;

--- a/tests/api.rs
+++ b/tests/api.rs
@@ -3,7 +3,7 @@
 use std::ops::{Deref, DerefMut};
 
 use scroll::ctx::SizeWith as _;
-use scroll::{ctx, Cread, Endian, Pread, Result};
+use scroll::{Cread, Endian, Pread, Result, ctx};
 
 #[derive(Default)]
 pub struct Section<'a> {
@@ -365,7 +365,7 @@ fn cwrite_api_customtype() {
 
 #[test]
 fn test_fixed_array_rw() {
-    use scroll::{ctx::MeasureWith, Endian, Pread, Pwrite};
+    use scroll::{Endian, Pread, Pwrite, ctx::MeasureWith};
     let bytes = [0x37, 0x13, 0x37, 0x13];
     assert_eq!(bytes.measure_with(&()), 4);
     assert_eq!(


### PR DESCRIPTION
This was discussed in #111, so I figured I'd do this too while I was at it.